### PR TITLE
Update build.zig for newer zig 0.11.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,9 +16,9 @@ pub fn build(b: *std.Build) !void {
 		.optimize = optimize,
 	});
 	exe.addModule("httpz", httpz_module);
-	exe.install();
+	b.installArtifact(exe);
 
-	const run_cmd = exe.run();
+	const run_cmd = b.addRunArtifact(exe);
 	run_cmd.step.dependOn(b.getInstallStep());
 	if (b.args) |args| {
 		run_cmd.addArgs(args);


### PR DESCRIPTION
Replaced two deprecations, reported as errors at `zig build` time in zig ver. `0.11.0-dev.2614+7b908e173` or newer (such as `0.11.0-dev.2624+bc804eb84`).