### PR TITLE
Add std.os.maybeIgnoreSigpipe to ignore SIGPIPE errors 

### DIFF
--- a/src/listener.zig
+++ b/src/listener.zig
@@ -61,6 +61,8 @@ pub fn initReqResPool(httpz_allocator: Allocator, app_allocator: Allocator, conf
 }
 
 pub fn handleConnection(comptime S: type, server: S, conn: Conn, reqResPool: *ReqResPool) void {
+    std.os.maybeIgnoreSigpipe();
+
 	const stream = if (comptime builtin.is_test) conn else conn.stream;
 	defer stream.close();
 


### PR DESCRIPTION
On linux by default the SIGPIPE signal kills your program. Zig actually by default registers a handler to avoid this, but this doesn't count for spawned threats.

So basically currently when I reload a page very quickly (hold down shift-r in firefox) I can crash the application because it either opens too many ports or reuses one, not sure. 
By calling maybeIgnoreSigpipe, an empty pipehandler is registered for the threads handling connections, avoiding the crash.