### PR TITLE
Broken pipe error handling - skip code that attempts to write error details to the broken connection

### DIFF
--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -294,6 +294,9 @@ pub fn ServerCtx(comptime G: type, comptime R: type) type {
 					res.body = "Request body is too big";
 					res.write() catch return false;
 				},
+                error.BrokenPipe => {
+                    return false;
+                },
 				else => {
 					if (comptime G == void) {
 						self._errorHandler(req, res, err);

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -295,6 +295,10 @@ pub fn ServerCtx(comptime G: type, comptime R: type) type {
 					res.write() catch return false;
 				},
                 error.BrokenPipe => {
+                    // TODO - IF this is correct, then there is probably a range of IO related errors that should
+                    // be trieated the same way. ie - the network connection is no longer valid, so dont 
+                    // try to write a response to it
+                    // MAYBE - allow the user to set a different errorHandler for these sort of conditions
                     return false;
                 },
 				else => {

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -296,7 +296,7 @@ pub fn ServerCtx(comptime G: type, comptime R: type) type {
 				},
                 error.BrokenPipe => {
                     // TODO - IF this is correct, then there is probably a range of IO related errors that should
-                    // be trieated the same way. ie - the network connection is no longer valid, so dont 
+                    // be treated the same way. ie - the network connection is no longer valid, so dont 
                     // try to write a response to it
                     // MAYBE - allow the user to set a different errorHandler for these sort of conditions
                     return false;


### PR DESCRIPTION
When there is an error due to a broken connection, the existing logic treats this as a standard error, which then calls an error handler and/or writes some error code to the response.

We should treat IO errors as a different case - and not attempt to write to the known-broken connection.

Attempting to write to the connection may also create some allocations that we wont need as well (ensureSpace on the buffer)