### PR TITLE
use config to define an optional Thread pool

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -3,23 +3,24 @@ const request = @import("request.zig");
 const response = @import("response.zig");
 
 pub const Config = struct {
-	// done like this so that an external app can access it as
-	// httpz.Config.Request or httpz.Config.Response
-	pub const Pool = pool.Config;
-	pub const Request = request.Config;
-	pub const Response = response.Config;
+    // done like this so that an external app can access it as
+    // httpz.Config.Request or httpz.Config.Response
+    pub const Pool = pool.Config;
+    pub const Request = request.Config;
+    pub const Response = response.Config;
 
-	port: ?u16 = null,
-	address: ?[]const u8 = null,
-	pool: Pool = Pool{},
-	request: Request = Request{},
-	response: Response = Response{},
-	cors: ?CORS = null,
+    port: ?u16 = null,
+    address: ?[]const u8 = null,
+    pool: Pool = Pool{},
+    thread_pool: u32 = 0,
+    request: Request = Request{},
+    response: Response = Response{},
+    cors: ?CORS = null,
 
-	pub const CORS = struct {
-		origin: []const u8,
-		headers: ?[]const u8 = null,
-		methods: ?[]const u8 = null,
-		max_age: ?[]const u8 = null,
-	};
+    pub const CORS = struct {
+        origin: []const u8,
+        headers: ?[]const u8 = null,
+        methods: ?[]const u8 = null,
+        max_age: ?[]const u8 = null,
+    };
 };

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -296,7 +296,7 @@ pub fn ServerCtx(comptime G: type, comptime R: type) type {
 					res.body = "Request body is too big";
 					res.write() catch return false;
 				},
-				error.BrokenPipe, error.ConnectionResetByPeer => {
+				error.BrokenPipe, error.ConnectionResetByPeer, error.Unexpected => {
 					// TODO: maybe allow the user to set a different errorHandler for these sort of conditions
 					return false;
 				},

--- a/src/listener.zig
+++ b/src/listener.zig
@@ -17,104 +17,115 @@ const net = std.net;
 const ReqResPool = Pool(*RequestResponsePair, RequestResponsePairConfig);
 
 pub fn listen(comptime S: type, httpz_allocator: Allocator, app_allocator: Allocator, server: S, config: Config) !void {
-	var reqResPool = try initReqResPool(httpz_allocator, app_allocator, &config);
-	defer reqResPool.deinit();
+    var reqResPool = try initReqResPool(httpz_allocator, app_allocator, &config);
+    defer reqResPool.deinit();
 
-	var socket = net.StreamServer.init(.{
-		.reuse_address = true,
-		.kernel_backlog = 1024,
-	});
-	defer socket.deinit();
+    var socket = net.StreamServer.init(.{
+        .reuse_address = true,
+        .kernel_backlog = 1024,
+    });
+    defer socket.deinit();
 
-	const listen_port = config.port.?;
-	const listen_address = config.address.?;
-	try socket.listen(net.Address.parseIp(listen_address, listen_port) catch unreachable);
+    var thread_pool: std.Thread.Pool = undefined;
+    if (config.thread_pool > 0) {
+        try std.Thread.Pool.init(&thread_pool, .{ .allocator = app_allocator, .n_jobs = config.thread_pool });
+    }
 
-	// TODO: I believe this should work, but it currently doesn't on 0.11-dev. Instead I have to
-	// hardcode 1 for the setsocopt NODELAY option
-	// if (@hasDecl(os.TCP, "NODELAY")) {
-	// 	try os.setsockopt(socket.sockfd.?, os.IPPROTO.TCP, os.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
-	// }
-	try os.setsockopt(socket.sockfd.?, os.IPPROTO.TCP, 1, &std.mem.toBytes(@as(c_int, 1)));
+    const listen_port = config.port.?;
+    const listen_address = config.address.?;
+    try socket.listen(net.Address.parseIp(listen_address, listen_port) catch unreachable);
 
-	while (true) {
-		if (socket.accept()) |conn| {
-			const c: Conn = if (comptime builtin.is_test) undefined else conn;
-			const args = .{S, server, c, &reqResPool};
-			if (comptime std.io.is_async) {
-				try Loop.instance.?.runDetached(httpz_allocator, handleConnection, args);
-			} else {
-				const thrd = try std.Thread.spawn(.{}, handleConnection, args);
-				thrd.detach();
-			}
-		} else |err| {
-			std.log.err("http.zig: failed to accept connection {}", .{err});
-		}
-	}
+    // TODO: I believe this should work, but it currently doesn't on 0.11-dev. Instead I have to
+    // hardcode 1 for the setsocopt NODELAY option
+    // if (@hasDecl(os.TCP, "NODELAY")) {
+    // 	try os.setsockopt(socket.sockfd.?, os.IPPROTO.TCP, os.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
+    // }
+    try os.setsockopt(socket.sockfd.?, os.IPPROTO.TCP, 1, &std.mem.toBytes(@as(c_int, 1)));
+
+    while (true) {
+        if (socket.accept()) |conn| {
+            const c: Conn = if (comptime builtin.is_test) undefined else conn;
+            const args = .{ S, server, c, &reqResPool };
+            if (comptime std.io.is_async) {
+                try Loop.instance.?.runDetached(httpz_allocator, handleConnection, args);
+            } else {
+                if (config.thread_pool > 0) {
+                    try thread_pool.spawn(handleConnection, args);
+                } else {
+                    const thrd = try std.Thread.spawn(.{}, handleConnection, args);
+                    thrd.detach();
+                }
+            }
+        } else |err| {
+            std.log.err("http.zig: failed to accept connection {}", .{err});
+        }
+    }
 }
 
 pub fn initReqResPool(httpz_allocator: Allocator, app_allocator: Allocator, config: *const Config) !ReqResPool {
-	return try ReqResPool.init(httpz_allocator, config.pool, initReqRes, .{
-		.config = config,
-		.app_allocator = app_allocator,
-		.httpz_allocator = httpz_allocator,
-	});
+    return try ReqResPool.init(httpz_allocator, config.pool, initReqRes, .{
+        .config = config,
+        .app_allocator = app_allocator,
+        .httpz_allocator = httpz_allocator,
+    });
 }
 
 pub fn handleConnection(comptime S: type, server: S, conn: Conn, reqResPool: *ReqResPool) void {
-	std.os.maybeIgnoreSigpipe();
+    std.os.maybeIgnoreSigpipe();
 
-	const stream = if (comptime builtin.is_test) conn else conn.stream;
-	defer stream.close();
+    const stream = if (comptime builtin.is_test) conn else conn.stream;
+    defer stream.close();
 
-	const reqResPair = reqResPool.acquire() catch |err| {
-		stream.writeAll("HTTP/1.1 503\r\nRetry-After: 10\r\nContent-Length: 36\r\n\r\nServer overloaded. Please try again.") catch {};
-		std.log.err("http.zig: failed to acquire request and response object from the pool {}", .{err});
-		return;
-	};
-	defer reqResPool.release(reqResPair);
+    const reqResPair = reqResPool.acquire() catch |err| {
+        stream.writeAll("HTTP/1.1 503\r\nRetry-After: 10\r\nContent-Length: 36\r\n\r\nServer overloaded. Please try again.") catch {};
+        std.log.err("http.zig: failed to acquire request and response object from the pool {}", .{err});
+        return;
+    };
+    defer reqResPool.release(reqResPair);
 
-	const req = reqResPair.request;
-	const res = reqResPair.response;
-	var arena = reqResPair.arena;
+    const req = reqResPair.request;
+    const res = reqResPair.response;
+    var arena = reqResPair.arena;
 
-	res.stream = stream;
-	req.stream = stream;
-	req.address = conn.address;
+    res.stream = stream;
+    req.stream = stream;
+    req.address = conn.address;
 
-	while (true) {
-		req.reset();
-		res.reset();
-		defer _ = arena.reset(.free_all);
+    while (true) {
+        req.reset();
+        res.reset();
+        defer _ = arena.reset(.free_all);
 
-		if (req.parse()) {
-			if (!server.handle(req, res)) {
-				return;
-			}
-		} else |err| {
-			// hard to keep this request alive on a parseError since in a lot of
-			// failure cases, it's unclear where 1 request stops and another starts.
-			requestParseError(err, res);
-			return;
-		}
-		req.drain() catch { return; };
-	}
+        if (req.parse()) {
+            if (!server.handle(req, res)) {
+                return;
+            }
+        } else |err| {
+            // hard to keep this request alive on a parseError since in a lot of
+            // failure cases, it's unclear where 1 request stops and another starts.
+            requestParseError(err, res);
+            return;
+        }
+        req.drain() catch {
+            return;
+        };
+    }
 }
 
 fn requestParseError(err: anyerror, res: *httpz.Response) void {
-	switch (err) {
-		error.UnknownMethod, error.InvalidRequestTarget, error.UnknownProtocol, error.UnsupportedProtocol, error.InvalidHeaderLine => {
-			res.status = 400;
-			res.body = "Invalid Request";
-			res.write() catch {};
-		},
-		error.HeaderTooBig => {
-			res.status = 431;
-			res.body = "Request header is too big";
-			res.write() catch {};
-		},
-		else => {},
-	}
+    switch (err) {
+        error.UnknownMethod, error.InvalidRequestTarget, error.UnknownProtocol, error.UnsupportedProtocol, error.InvalidHeaderLine => {
+            res.status = 400;
+            res.body = "Invalid Request";
+            res.write() catch {};
+        },
+        error.HeaderTooBig => {
+            res.status = 431;
+            res.body = "Request header is too big";
+            res.write() catch {};
+        },
+        else => {},
+    }
 }
 
 // We pair together requests and responses, not because they're tightly coupled,
@@ -122,54 +133,54 @@ fn requestParseError(err: anyerror, res: *httpz.Response) void {
 // Also, both the request and response can require dynamic memory allocation.
 // Grouping them this way means we can create 1 arena per pair.
 const RequestResponsePair = struct {
-	allocator: Allocator,
-	request: *httpz.Request,
-	response: *httpz.Response,
-	arena: *std.heap.ArenaAllocator,
+    allocator: Allocator,
+    request: *httpz.Request,
+    response: *httpz.Response,
+    arena: *std.heap.ArenaAllocator,
 
-	const Self = @This();
+    const Self = @This();
 
-	pub fn deinit(self: *Self, httpz_allocator: Allocator) void {
-		self.request.deinit(httpz_allocator);
-		httpz_allocator.destroy(self.request);
+    pub fn deinit(self: *Self, httpz_allocator: Allocator) void {
+        self.request.deinit(httpz_allocator);
+        httpz_allocator.destroy(self.request);
 
-		self.response.deinit(httpz_allocator);
-		httpz_allocator.destroy(self.response);
-		self.arena.deinit();
-		httpz_allocator.destroy(self.arena);
-		httpz_allocator.destroy(self);
-	}
+        self.response.deinit(httpz_allocator);
+        httpz_allocator.destroy(self.response);
+        self.arena.deinit();
+        httpz_allocator.destroy(self.arena);
+        httpz_allocator.destroy(self);
+    }
 };
 
 const RequestResponsePairConfig = struct {
-	config: *const Config,
-	app_allocator: Allocator,
-	httpz_allocator: Allocator,
+    config: *const Config,
+    app_allocator: Allocator,
+    httpz_allocator: Allocator,
 };
 
 // Should not be called directly, but initialized through a pool
 pub fn initReqRes(c: RequestResponsePairConfig) !*RequestResponsePair {
-	const httpz_allocator = c.httpz_allocator;
+    const httpz_allocator = c.httpz_allocator;
 
-	var arena = try httpz_allocator.create(std.heap.ArenaAllocator);
-	arena.* = std.heap.ArenaAllocator.init(c.app_allocator);
-	const app_allocator = arena.allocator();
+    var arena = try httpz_allocator.create(std.heap.ArenaAllocator);
+    arena.* = std.heap.ArenaAllocator.init(c.app_allocator);
+    const app_allocator = arena.allocator();
 
-	var req = try httpz_allocator.create(httpz.Request);
-	try req.init(httpz_allocator, app_allocator, c.config.request);
+    var req = try httpz_allocator.create(httpz.Request);
+    try req.init(httpz_allocator, app_allocator, c.config.request);
 
-	var res = try httpz_allocator.create(httpz.Response);
-	try res.init(httpz_allocator, app_allocator, c.config.response);
+    var res = try httpz_allocator.create(httpz.Response);
+    try res.init(httpz_allocator, app_allocator, c.config.response);
 
-	var pair = try httpz_allocator.create(RequestResponsePair);
-	pair.* = .{
-		.arena = arena,
-		.request = req,
-		.response = res,
-		.allocator = app_allocator,
-	};
+    var pair = try httpz_allocator.create(RequestResponsePair);
+    pair.* = .{
+        .arena = arena,
+        .request = req,
+        .response = res,
+        .allocator = app_allocator,
+    };
 
-	return pair;
+    return pair;
 }
 
 // All of this logic is largely tested in httpz.zig


### PR DESCRIPTION
Using an extra config var to define an optional thread pool in http.zig

if set to 0, then it threads as per normal ... no change in behaviour

If set to > 0, then it uses std.Thread.Pool set to that size to have a limited pool of threads.
Result is that memory consumption is greatly reduced, and remains flat over a long period.
(there might be a problem with thread spawn + detach in zig stdlib, but I cant prove it yet)

See discussion on zig discord - search in help topic for
"std.Thread.detach() - possible resource leak ?"