### PR TITLE
Websocket align fix

### DIFF
--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -929,11 +929,17 @@ test "websocket: upgrade" {
     try stream.writeAll(&websocket.frameBin("close"));
 
     var buf: [20]u8 = undefined;
-    const n = try stream.read(&buf);
-    try t.expectEqual(12, n);
-    try t.expectEqual(129, buf[0]);
-    try t.expectEqual(10, buf[1]);
-    try t.expectString("over 9000!", buf[2..12]);
+    {
+        const n = try stream.read(&buf);
+        try t.expectEqual(2, n);
+        try t.expectEqual(129, buf[0]);
+        try t.expectEqual(10, buf[1]);
+    }
+    {
+        const n = try stream.read(&buf);
+        try t.expectEqual(10, n);
+        try t.expectString("over 9000!", buf[0..n]);
+    }
 }
 
 test "httpz: keepalive" {

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -46,7 +46,7 @@ pub fn Worker(comptime S: type) type {
         config: *const Config,
 
         signal_pos: usize,
-        signal_buf: [@sizeOf(usize) * 64]u8,
+        signal_buf: [64]usize,
 
         const Self = @This();
 
@@ -216,7 +216,8 @@ pub fn Worker(comptime S: type) type {
         fn processSignal(self: *Self, signal: os.fd_t) bool {
             const s_t = @sizeOf(usize);
 
-            const buf = &self.signal_buf;
+            const buflen = @typeInfo(@TypeOf(self.signal_buf)).Array.len * @sizeOf(usize);
+            const buf: *[buflen]u8 = @ptrCast(&self.signal_buf);
             const start = self.signal_pos;
 
             const n = os.read(signal, buf[start..]) catch |err| switch (err) {


### PR DESCRIPTION
here is the error from before the second commit

```console
tmp/http.zig $ zig build test
.....warning: httpz: unhandled exception for request: /fail
Err: error.TestUnhandledError
..............expected 12, found 2

================================================================================
"websocket: upgrade" - TestExpectedEqual
================================================================================
/media/travis/data/Users/Travis/Documents/Code/zig/zig/download/0.12.0-dev.2540+776cd673f/files/lib/std/testing.zig:93:17: 0x10ca11b in expectEqualInner__anon_6808 (test)
                return error.TestExpectedEqual;
                ^
/tmp/http.zig/src/t.zig:12:5: 0x10ca18b in expectEqual__anon_6807 (test)
    try std.testing.expectEqual(@as(@TypeOf(actual), expected), actual);
    ^
/tmp/http.zig/src/httpz.zig:933:5: 0x10caa7c in test.websocket: upgrade (test)
    try t.expectEqual(12, n);
    ^
.............................................................
79 of 80 tests passed

Slowest 5 tests: 
  2962.55ms	httpz: router groups
  5203.85ms	httpz: writer re-use
  18999.85ms	response: write header_buffer_size
  26879.47ms	response: writer fuzz
  90680.77ms	response: json fuzz

test
└─ run test failure
error: the following command exited with error code 1:
/tmp/http.zig/zig-cache/o/cdf9fc59df35d7fc512a291787abaa57/test 
Build Summary: 1/3 steps succeeded; 1 failed (disable with --summary none)
test transitive failure
└─ run test failure
error: the following build command failed with exit code 1:
/tmp/http.zig/zig-cache/o/8376579579775ee1e93265025a03788b/build /media/travis/data/Users/Travis/Documents/Code/zig/zig/download/0.12.0-dev.2540+776cd673f/files/zig /tmp/http.zig /tmp/http.zig/zig-cache /home/travis/.cache/zig --seed 0x1d7a71c6 test
```