### PR TITLE
thread pool 0.12 compatiblity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 F=
+zig ?= zig
 .PHONY: t
 t:
-	TEST_FILTER="${F}" zig build test -freference-trace --summary all
-	TEST_FILTER="${F}" zig build test_blocking -freference-trace --summary all
+	TEST_FILTER='${F}' '${zig}' build test -freference-trace --summary all
+	TEST_FILTER='${F}' '${zig}' build test_blocking -freference-trace --summary all
 
 .PHONY: tn
-	TEST_FILTER="${F}" zig build test -freference-trace --summary all
+	TEST_FILTER='${F}' '${zig}' build test -freference-trace --summary all
 
 .PHONY: tb
 tb:
-	TEST_FILTER="${F}" zig build test_blocking -freference-trace --summary all
+	TEST_FILTER='${F}' '${zig}' build test_blocking -freference-trace --summary all
 
 .PHONY: s
 s:


### PR DESCRIPTION
- **ThreadPool 0.12 compatibility**
- **Allow providing zig executable for running tests**

@karlseguin Feel free to reject if you don't care about 0.12 compatibility - I'm hoping to maintain support for 0.12 at least for a while.