### PR TITLE
remove tab in comment

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) !void {
     const websocket_module = b.dependency("websocket", dep_opts).module("websocket");
 
     // const websocket_module = b.addModule("websocket", .{
-    //     .root_source_file = b.path("..//websocket.zig/src/websocket.zig"),
+    //    .root_source_file = b.path("..//websocket.zig/src/websocket.zig"),
     // });
 
     const httpz_module = b.addModule("httpz", .{


### PR DESCRIPTION
another one hidden in a comment

Only shows up as a problem when you include httpz from another repo - trips up the compiler again 