### PR TITLE
fixed typos and removed code duplication in key_value.zig

### DIFF
--- a/src/buffer.zig
+++ b/src/buffer.zig
@@ -180,7 +180,7 @@ test "BufferPool" {
 
         try t.expectEqual(false, &buf1.data[0] == &buf2.data[0]);
 
-        // no more buffers in the pool, creats a dynamic buffer
+        // no more buffers in the pool, creates a dynamic buffer
         const buf3 = try pool.alloc(6);
         try t.expectEqual(.dynamic, buf3.type);
         try t.expectEqual(6, buf3.data.len);

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -825,7 +825,7 @@ test "httpz: invalid request" {
 test "httpz: invalid request path" {
     const stream = testStream(5992);
     defer stream.close();
-    try stream.writeAll("TEA /helo\rn\nWorld:test HTTP/1.1\r\n\r\n");
+    try stream.writeAll("TEA /hello\rn\nWorld:test HTTP/1.1\r\n\r\n");
 
     var buf: [100]u8 = undefined;
     try t.expectString("HTTP/1.1 400 \r\nConnection: Close\r\nContent-Length: 15\r\n\r\nInvalid Request", testReadAll(stream, &buf));

--- a/src/key_value.zig
+++ b/src/key_value.zig
@@ -4,116 +4,79 @@ const mem = std.mem;
 const ascii = std.ascii;
 const Allocator = std.mem.Allocator;
 
-pub const KeyValue = struct {
-    len: usize,
-    keys: [][]const u8,
-    values: [][]const u8,
+fn MakeKeyValue(keyType: type, valueType: type, equalFn: fn (lhs: keyType, rhs: keyType) bool) type {
+    return struct {
+        len: usize,
+        keys: []keyType,
+        values: []valueType,
 
-    pub fn init(allocator: Allocator, max: usize) !KeyValue {
-        const keys = try allocator.alloc([]const u8, max);
-        const values = try allocator.alloc([]const u8, max);
-        return .{
-            .len = 0,
-            .keys = keys,
-            .values = values,
-        };
-    }
-
-    pub fn deinit(self: *KeyValue, allocator: Allocator) void {
-        allocator.free(self.keys);
-        allocator.free(self.values);
-    }
-
-    pub fn add(self: *KeyValue, key: []const u8, value: []const u8) void {
-        const len = self.len;
-        var keys = self.keys;
-        if (len == keys.len) {
-            return;
+        // This is used in some tests for 
+        pub const Value = valueType;
+        const Self = @This();
+        pub fn init(allocator: Allocator, max: usize) !Self {
+            return .{
+                .len = 0,
+                .keys = try allocator.alloc(keyType, max),
+                .values = try allocator.alloc(valueType, max),
+            };
         }
 
-        keys[len] = key;
-        self.values[len] = value;
-        self.len = len + 1;
-    }
+        pub fn deinit(self: *Self, allocator: Allocator) void {
+            allocator.free(self.keys);
+            allocator.free(self.values);
+        }
 
-    pub fn get(self: KeyValue, needle: []const u8) ?[]const u8 {
-        const keys = self.keys[0..self.len];
-        loop: for (keys, 0..) |key, i| {
-            // This is largely a reminder to myself that std.mem.eql isn't
-            // particularly fast. Here we at least avoid the 1 extra ptr
-            // equality check that std.mem.eql does, but we could do better
-            // TODO: monitor https://github.com/ziglang/zig/issues/8689
-            if (needle.len != key.len) {
-                continue;
+        pub fn add(self: *Self, key: keyType, value: valueType) void {
+            const len = self.len;
+            var keys = self.keys;
+            if (len == keys.len) {
+                return;
             }
-            for (needle, key) |n, k| {
-                if (n != k) {
-                    continue :loop;
+
+            keys[len] = key;
+            self.values[len] = value;
+            self.len = len + 1;
+        }
+
+        pub fn get(self: *const Self, needle: keyType) ?valueType {
+            const keys = self.keys[0..self.len];
+            for (keys, 0..) |key, i| {
+                if (equalFn(key, needle)) {
+                    // return key;
+                    return self.values[i];
                 }
             }
-            return self.values[i];
+            return null;
         }
 
-        return null;
-    }
-
-    pub fn reset(self: *KeyValue) void {
-        self.len = 0;
-    }
-};
-
-pub const MultiFormKeyValue = struct {
-    len: usize,
-    keys: [][]const u8,
-    values: []Value,
-
-   pub const Value = struct {
-        value: []const u8,
-        filename: ?[]const u8 = null,
+        pub fn reset(self: *Self) void {
+            self.len = 0;
+        }
     };
+}
 
-    pub fn init(allocator: Allocator, max: usize) !MultiFormKeyValue {
-        const keys = try allocator.alloc([]const u8, max);
-        const values = try allocator.alloc(Value, max);
-        return .{
-            .len = 0,
-            .keys = keys,
-            .values = values,
-        };
+fn strEql(lhs: []const u8, rhs: []const u8) bool {
+    // This is largely a reminder to myself that std.mem.eql isn't
+    // particularly fast. Here we at least avoid the 1 extra ptr
+    // equality check that std.mem.eql does, but we could do better
+    // TODO: monitor https://github.com/ziglang/zig/issues/8689
+    if (lhs.len != rhs.len) {
+        return false;
     }
-
-    pub fn deinit(self: *MultiFormKeyValue, allocator: Allocator) void {
-        allocator.free(self.keys);
-        allocator.free(self.values);
+    for (lhs, rhs) |l, r| {
+        if (l != r) return false;
     }
+    return true;
+}
 
-    pub fn add(self: *MultiFormKeyValue, key: []const u8, value: Value) void {
-        const len = self.len;
-        var keys = self.keys;
-        if (len == keys.len) {
-            return;
-        }
+pub const KeyValue = MakeKeyValue([]const u8, []const u8, strEql);
 
-        keys[len] = key;
-        self.values[len] = value;
-        self.len = len + 1;
-    }
-
-    pub fn get(self: MultiFormKeyValue, needle: []const u8) ?Value {
-        const keys = self.keys[0..self.len];
-        for (keys, 0..) |key, i| {
-            if (mem.eql(u8, key, needle)) {
-                return self.values[i];
-            }
-        }
-
-        return null;
-    }
-
-    pub fn reset(self: *MultiFormKeyValue) void {
-        self.len = 0;
-    }
+const MultiForm = struct {
+    value: []const u8,
+    filename: ?[]const u8 = null,
 };
+pub const MultiFormKeyValue = MakeKeyValue([]const u8, MultiForm, strEql);
+
 
 const t = @import("t.zig");
 test "KeyValue: get" {

--- a/src/request.zig
+++ b/src/request.zig
@@ -340,7 +340,7 @@ pub const Request = struct {
     // I'm sorry
     fn parseMultiPartEntry(entry: []const u8) !MultiPartField {
         var pos: usize = 0;
-        var attributes: ?ContentDispostionAttributes = null;
+        var attributes: ?ContentDispositionAttributes = null;
 
         while (true) {
             const end_line_pos = std.mem.indexOfScalarPos(u8, entry, pos, '\n') orelse return error.InvalidMultiPartEncoding;
@@ -385,13 +385,13 @@ pub const Request = struct {
         };
     }
 
-    const ContentDispostionAttributes = struct {
+    const ContentDispositionAttributes = struct {
         name: []const u8,
         filename: ?[]const u8 = null,
     };
 
     // I'm sorry
-    fn getContentDispotionAttributes(fields: []u8) !ContentDispostionAttributes{
+    fn getContentDispotionAttributes(fields: []u8) !ContentDispositionAttributes{
         var pos: usize = 0;
 
         var name: ?[]const u8 = null;
@@ -841,7 +841,7 @@ pub const State = struct {
             return true;
         }
 
-        // how much fo the body are we missing
+        // how much of the body are we missing
         const missing = cl - read;
 
         // how much spare space we have in our static buffer
@@ -1433,7 +1433,7 @@ test "body: multiFormData valid" {
 test "body: multiFormData invalid" {
     defer t.reset();
     {
-        // large boudary
+        // large boundary
         var r = try testParse(buildRequest(&.{
             "POST / HTTP/1.0",
             "Content-Type: multipart/form-data; boundary=12345678901234567890123456789012345678901234567890123456789012345678901"
@@ -1451,7 +1451,7 @@ test "body: multiFormData invalid" {
     }
 
     {
-        // no content-dispostion field header
+        // no content-disposition field header
         var r = try testParse(buildRequest(&.{
             "POST / HTTP/1.0",
             "Content-Type: multipart/form-data; boundary=-90x"
@@ -1569,7 +1569,7 @@ test "request: fuzz" {
                 const value = t.randomString(random, aa, 20);
                 if (!query.contains(key)) {
                     // TODO: figure out how we want to handle duplicate query values
-                    // (the spec doesn't specifiy what to do)
+                    // (the spec doesn't specify what to do)
                     query.put(key, value) catch unreachable;
                     ctx.write(key);
                     ctx.write("=");

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -304,7 +304,7 @@ fn decodeChunkedEncoding(full_dest: []u8, full_src: []u8) usize {
 
         if (src.len < next_start and clean_trailer == false) {
             // This should not happen, but...When http.zig writes a chunked
-            // response, the trailing empty chunk ony gets written deep in the
+            // response, the trailing empty chunk only gets written deep in the
             // library. When calling a handler directly from a test, that part
             // of the library isn't executed, and thus an invalid chunked encoded
             // body is written (it's missing that empty trailing chunk).

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -310,7 +310,7 @@ pub const Conn = struct {
     // number of requests made on this connection (within a keepalive session)
     request_count: u64,
 
-    // whether or not to close the connection after the resposne is sent
+    // whether or not to close the connection after the response is sent
     close: bool,
 
     stream: std.net.Stream,
@@ -1076,7 +1076,7 @@ pub fn Blocking(comptime S: type) type {
                             // We would have been on a keepalive timeout (if there was one),
                             // and now need to switch to a request timeout. This might be
                             // an actual timeout, or it could just be removing the keepalive timeout
-                            // eitehr way, it's the same code (timeval will just be set to 0 for
+                            // either way, it's the same code (timeval will just be set to 0 for
                             // the second case)
                             deadline = timestamp() + to.sec;
                             try posix.setsockopt(stream.handle, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &to.timeval);
@@ -1114,7 +1114,7 @@ fn initializeBufferPool(allocator: Allocator, config: *const Config) !BufferPool
 
 // Handles parsing errors. If this returns true, it means Conn has a body ready
 // to write. In this case the worker (blocking or nonblocking) will want to send
-// the resposne. If it returns false, the worker probably wants to close the connection.
+// the response. If it returns false, the worker probably wants to close the connection.
 // This function ensures that both Blocking and NonBlocking workers handle these
 // errors with the same response
 fn requestParseError(conn: *Conn, err: anyerror) !void {


### PR DESCRIPTION
additionally httpz.zig:828 has `TEA /hello\rn\nWorld:test HTTP/1.1\r\n\r\n`
is 'n' in hello\r***n***\n intentional