### PR TITLE
Print debug stack trace on uncaught error

### DIFF
--- a/examples/02_handler.zig
+++ b/examples/02_handler.zig
@@ -16,7 +16,10 @@ pub fn main() !void {
     // We specify our "Handler" and, as the last parameter to init, pass an
     // instance of it.
     var handler = Handler{};
-    var server = try httpz.Server(*Handler).init(allocator, .{ .port = PORT }, &handler);
+    var server = try httpz.Server(*Handler).init(allocator, .{
+        .port = PORT,
+        .print_uncaught_error_stack_trace = .debug,
+    }, &handler);
 
     defer server.deinit();
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,6 +1,7 @@
 const httpz = @import("httpz.zig");
 const request = @import("request.zig");
 const response = @import("response.zig");
+const std = @import("std");
 
 // don't like using CPU detection since hyperthread cores are marketing.
 const DEFAULT_WORKERS = 2;
@@ -15,6 +16,7 @@ pub const Config = struct {
     timeout: Timeout = .{},
     thread_pool: ThreadPool = .{},
     websocket: Websocket = .{},
+    print_uncaught_error_stack_trace: ?std.log.Level = null,
 
     pub const ThreadPool = struct {
         count: ?u16 = null,

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -538,7 +538,6 @@ pub fn Server(comptime H: type) type {
             var req = Request.init(allocator, conn);
             var res = Response.init(allocator, conn);
 
-
             if (comptime std.meta.hasFn(Handler, "handle")) {
                 if (comptime @typeInfo(@TypeOf(Handler.handle)).@"fn".return_type != void) {
                     @compileError(@typeName(Handler) ++ ".handle must return 'void'");
@@ -565,6 +564,12 @@ pub fn Server(comptime H: type) type {
                 }
 
                 executor.next() catch |err| {
+                    if (self.config.print_uncaught_error_stack_trace) |level| {
+                        switch (level) {
+                            inline else => |v| std.log.defaultLog(v, .default, "{any}", .{@errorReturnTrace()}),
+                        }
+                    }
+
                     if (comptime std.meta.hasFn(Handler, "uncaughtError")) {
                         self.handler.uncaughtError(&req, &res, err);
                     } else {


### PR DESCRIPTION
Sometimes u need know stack trace of ur error, to understand problem.

example of print error debug:
<img width="817" alt="image" src="https://github.com/user-attachments/assets/7e3296ca-8140-4c10-b646-ba1749d33c48">


wdyt?