### PR TITLE
router: Add support for custom HTTP methods

### DIFF
--- a/examples/01_basic.zig
+++ b/examples/01_basic.zig
@@ -33,7 +33,7 @@ pub fn main() !void {
 
     // Register routes. The last parameter is a Route Config. For these basic
     // examples, we aren't using it.
-    // Other support methods: post, put, delete, head, trace, options and all
+    // Other support methods: post, put, delete, head, trace, options, and custom methods
     router.get("/", index, .{});
     router.get("/hello", hello, .{});
     router.get("/json/hello/:name", json, .{});
@@ -42,6 +42,7 @@ pub fn main() !void {
     router.get("/form_data", formShow, .{});
     router.post("/form_data", formPost, .{});
     router.get("/explicit_write", explicitWrite, .{});
+    router.all("/method", method, .{});
 
     std.debug.print("listening http://localhost:{d}/\n", .{PORT});
 
@@ -122,4 +123,16 @@ fn explicitWrite(_: *httpz.Request, res: *httpz.Response) !void {
         \\ the issue, you can always call `res.write()` explicitly
     ;
     return res.write();
+}
+
+fn method(req: *httpz.Request, res: *httpz.Response) !void {
+    // handler will respond to any method <= 8 characters in length
+    const wtr = res.writer();
+    try wtr.writeAll(
+        \\ <html><body>You requested method: 
+    );
+    try req.method.write(wtr);
+    try wtr.writeAll(
+        \\ </body></html>
+    );
 }

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -858,15 +858,6 @@ test "httpz: quick shutdown" {
     server.deinit();
 }
 
-test "httpz: invalid request" {
-    const stream = testStream(5992);
-    defer stream.close();
-    try stream.writeAll("TEA / HTTP/1.1\r\n\r\n");
-
-    var buf: [100]u8 = undefined;
-    try t.expectString("HTTP/1.1 400 \r\nConnection: Close\r\nContent-Length: 15\r\n\r\nInvalid Request", testReadAll(stream, &buf));
-}
-
 test "httpz: invalid request path" {
     const stream = testStream(5992);
     defer stream.close();

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -41,15 +41,7 @@ pub const Protocol = enum {
     HTTP11,
 };
 
-pub const Method = enum {
-    GET,
-    HEAD,
-    POST,
-    PUT,
-    PATCH,
-    DELETE,
-    OPTIONS,
-};
+pub const Method = std.http.Method;
 
 pub const ContentType = enum {
     BINARY,

--- a/src/t.zig
+++ b/src/t.zig
@@ -270,7 +270,10 @@ pub const Context = struct {
 };
 
 pub fn randomString(random: std.Random, a: Allocator, max: usize) []u8 {
-    var buf = a.alloc(u8, random.uintAtMost(usize, max) + 1) catch unreachable;
+    return randomStringLengthRange(random, a, 0, max);
+}
+pub fn randomStringLengthRange(random: std.Random, a: Allocator, min: usize, max: usize) []u8 {
+    var buf = a.alloc(u8, random.intRangeAtMost(usize, min, max)) catch unreachable;
     const valid = "abcdefghijklmnopqrstuvwxyz0123456789-_";
     for (0..buf.len) |i| {
         buf[i] = valid[random.uintAtMost(usize, valid.len - 1)];


### PR DESCRIPTION
Allow routing methods which are not in the core HTTP spec; such as WebDAV PROPFIND method. Instead of defining our own Method enum we can use the one from the zig stdlib, which is non-exhaustive and provides the facility to parse custom methods.

I've taken the approach of providing a single fallback Action for non-standard HTTP methods. The downside is that only one Action can be registered to cover multiple methods, which will require the user to examine the Request.method member and switch on that inside their own handler.

An alternative approach would be to replace the list of Actions like _get with a map of some kind.