### PR TITLE
registerDispatcher function added to router

### DIFF
--- a/src/router.zig
+++ b/src/router.zig
@@ -90,6 +90,13 @@ pub fn Router(comptime Handler: type, comptime Action: type) type {
             };
         }
 
+        // Return a RouteConfig with the given dispatcher function embedded
+        pub fn registerDispatcher(_: Self, dispatcher: Dispatcher) RC {
+            return RC{
+                .dispatcher = dispatcher,
+            };
+        }
+
         pub fn get(self: *Self, path: []const u8, action: Action, config: RC) void {
             self.tryGet(path, action, config) catch @panic("failed to create route");
         }

--- a/src/router.zig
+++ b/src/router.zig
@@ -90,11 +90,9 @@ pub fn Router(comptime Handler: type, comptime Action: type) type {
             };
         }
 
-        // Return a RouteConfig with the given dispatcher function embedded
-        pub fn registerDispatcher(_: Self, dispatcher: Dispatcher) RC {
-            return RC{
-                .dispatcher = dispatcher,
-            };
+        /// routeConfig allows the user to pass an anon struct, and have it coerced into the correct RC type for this router
+        pub fn routeConfig(_: Self, config: RC) RC {
+            return config;
         }
 
         pub fn get(self: *Self, path: []const u8, action: Action, config: RC) void {


### PR DESCRIPTION
OK, this is an interesting problem :)

Recent update to Zig here https://github.com/ziglang/zig/pull/21817 - removes anon struct types from the language

(you can still use anon structs of course, but storing them in a local var, they no longer magically coerce into a matching type)

Side effect of this is .... 
I have an App that has a variety of different dispatchers, and LOTS of routes

Prior to this change, I was able to define various `RouteConfig` values in a set of local values like so : 

```zig
fn addRoutes(router: anytype) !void {
   const protected = .{ .dispatcher = middleware.protected };
   const public = .{ .dispatcher = middleware.open };
   const anonSession = .{ .dispatcher = middleware.anonSession };

   // then apply those configs to lots of routes
   router.get("/",  App.index, anonSession);
   router.get("/invoices", App.invoices, protected);
   ....   LOTS of routes
```

Now, that won't compile anymore 

A correct solution would now use something like this 

replace all my route definitions with this longer form

```zig
   router.get("/",  App.index, .{ .dispatcher = middleware.anonSession });
   router.get("/invoices", App.invoices, .{ .dispatcher = middleware.protected });
   .... LOTS of routes
```
(yuk !)

OR - 

```zig
  const protected: httpz.routing.RouteConfig(Handler, Action) = .{ .dispatcher = middleware.protected };
  ... etc
```

That's all pretty ugly / verbose.  Its also really difficult to make this work, since RouteConfig() is private,   the types `Handler` and `Action` are unknown at this point in my app code, and any attempt to export the RouteConfig type from inside the router instance in https ends up enforcing comptime-knowness to parts of my app code.

Simple solution for my one-off use case is to add this `registerDispatcher()` to the Router struct.  This is easy, because RC is already comptime known inside the router code.

End result is my app code looks like this : 

```zig
fn addRoutes(router: anytype) !void {
   const protected = router.registerDispatcher(middleware.protected);
   const public = router.registerDispatcher(middleware.open);
   const anonSession = router.registerDispatcher(middleware.anonSession };

   // then apply those consts, as before
   router.get("/",  App.index, anonSession);
   router.get("/invoices", App.invoices, protected);
   ....   LOTS of routes
```

Works great with this patch - even if its just really specific to my one-off problem here

------------------

A more general solution would be to have `registerConfig()` that took a struct like 

```zig
   struct {
        data: ?*const anyopaque = null,
        handler: ?Handler = null,
        dispatcher: ?Dispatcher = null,
        middlewares: ?[]const httpz.Middleware(Handler) = null,
        middleware_strategy: ?MiddlewareStrategy = null,
    };
```
and returned a value of type RC - which is easily computable inside the httpz.router code
 
... but that's not simple either, because again the app that would be using this doesnt necessarily have access to the 'Handler' type, which is needed at comptime to determine some of these values.

Not a fun problem :)

Im just going to run with my branch with this `registerDispatcher()` for now, because that solves my particular problem

