### PR TITLE
support infinitely large bodies

### DIFF
--- a/src/request.zig
+++ b/src/request.zig
@@ -974,7 +974,7 @@ pub const State = struct {
         self.body_len = cl;
         if (cl == 0) return true;
 
-        if (cl > self.max_body_size) {
+        if (self.lazy_read_size == null and cl > self.max_body_size) {
             metrics.bodyTooBig();
             return error.BodyTooBig;
         }


### PR DESCRIPTION
due to streaming of request bodies now being supported, limiting the body size only makes sense for memory allocation purposes. setting max_body_size to a large value would cause OOM since memory is eagerly allocated based on this value. it would be reasonable to rename max_body_size to eager_body_size.