### PR TITLE
Fix Test Utilities on Windows

### DIFF
--- a/src/t.zig
+++ b/src/t.zig
@@ -153,6 +153,7 @@ pub const Context = struct {
 
     fn setupFakeSocketPair(server: *posix.socket_t, client: *posix.socket_t) !void {
         const listener = posix.socket(posix.AF.INET, posix.SOCK.STREAM, 0) catch unreachable;
+        defer posix.close(listener);
 
         var address = try std.net.Address.parseIp("127.0.0.1", 0);
         try posix.setsockopt(listener, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
@@ -163,8 +164,8 @@ pub const Context = struct {
         try posix.getsockname(listener, &address.any, &len);
 
         var thread = try std.Thread.spawn(.{}, struct {
-            fn accept(listner: posix.socket_t, server_side: *posix.socket_t) !void {
-                server_side.* = try posix.accept(listner, null, null, 0);
+            fn accept(l: posix.socket_t, server_side: *posix.socket_t) !void {
+                server_side.* = try posix.accept(l, null, null, 0);
             }
         }.accept, .{listener, server});
 

--- a/src/t.zig
+++ b/src/t.zig
@@ -50,7 +50,7 @@ pub const Context = struct {
     _random: ?std.Random.DefaultPrng = null,
 
     pub fn allocInit(ctx_allocator: Allocator, config_: httpz.Config) Context {
-        var pair: [2]c_int = undefined;
+        var pair: [2]posix.socket_t = undefined;
         if (@import("builtin").os.tag == .windows) {
             // create the socket pair manually on Windows because `socketpair` does not exist on Windows
             // use INET instead of LOCAL because LOCAL is an alias for UNIX, which does not exist on Windows
@@ -167,7 +167,7 @@ pub const Context = struct {
             fn accept(l: posix.socket_t, server_side: *posix.socket_t) !void {
                 server_side.* = try posix.accept(l, null, null, 0);
             }
-        }.accept, .{listener, server});
+        }.accept, .{ listener, server });
 
         client.* = posix.socket(posix.AF.INET, posix.SOCK.STREAM, 0) catch unreachable;
         try posix.connect(client.*, &address.any, address.getOsSockLen());


### PR DESCRIPTION
`@import("httpz").testing` was not usable on Windows as intended (see [official testing docs](https://github.com/karlseguin/http.zig#testing)) due to the use of Unix-only socket creation. The sockets are now created to handle both Unix and Windows, depending on the targeted OS.

Closes #93