### PR TITLE
fix: zig master 0.14.0-dev.3026+c225b780e

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -1679,8 +1679,7 @@ pub fn timestamp(clamp: u32) u32 {
         const value: u32 = @intCast(std.time.timestamp());
         return if (value <= clamp) return clamp + 1 else value;
     }
-    var ts: posix.timespec = undefined;
-    posix.clock_gettime(posix.CLOCK.MONOTONIC, &ts) catch unreachable;
+    const ts = posix.clock_gettime(posix.CLOCK.MONOTONIC) catch unreachable;
     return @intCast(ts.sec);
 }
 


### PR DESCRIPTION
Hi, as you can see here https://github.com/ziglang/zig/pull/22627 there is a small change in the latest zig version for the `std.posix.clock_gettime` function (I’m testing it with 0.14.0-dev.3026+c225b780e) and it won’t compile anymore.

I’m a beginner in zig so do not hesitate if there is something wrong with the fix I suggest.