### PR TITLE
#110 Add a variant of startEventStream for returning the stream, instead of spawning a thread

### DIFF
--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -818,6 +818,7 @@ test "tests:beforeAll" {
         router.method("PING", "/test/method", TestDummyHandler.method, .{});
         router.get("/test/query", TestDummyHandler.reqQuery, .{});
         router.get("/test/stream", TestDummyHandler.eventStream, .{});
+        router.get("/test/stream", TestDummyHandler.eventStreamSync, .{});
         router.get("/test/req_reader", TestDummyHandler.reqReader, .{});
         router.get("/test/chunked", TestDummyHandler.chunked, .{});
         router.get("/test/route_data", TestDummyHandler.routeData, .{ .data = &TestDummyHandler.RouteData{ .power = 12345 } });
@@ -1601,6 +1602,14 @@ const TestDummyHandler = struct {
     fn eventStream(_: *Request, res: *Response) !void {
         res.status = 818;
         try res.startEventStream(StreamContext{ .data = "hello" }, StreamContext.handle);
+    }
+
+    fn eventStreamSync(_: *Request, res: *Response) !void {
+        res.status = 818;
+        const stream = try res.startEventStreamSync();
+        const w = stream.writer();
+        w.writeAll("hello") catch unreachable;
+        w.writeAll("a message") catch unreachable;
     }
 
     fn reqReader(req: *Request, res: *Response) !void {

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -818,7 +818,7 @@ test "tests:beforeAll" {
         router.method("PING", "/test/method", TestDummyHandler.method, .{});
         router.get("/test/query", TestDummyHandler.reqQuery, .{});
         router.get("/test/stream", TestDummyHandler.eventStream, .{});
-        router.get("/test/stream", TestDummyHandler.eventStreamSync, .{});
+        router.get("/test/streamsync", TestDummyHandler.eventStreamSync, .{});
         router.get("/test/req_reader", TestDummyHandler.reqReader, .{});
         router.get("/test/chunked", TestDummyHandler.chunked, .{});
         router.get("/test/route_data", TestDummyHandler.routeData, .{ .data = &TestDummyHandler.RouteData{ .power = 12345 } });
@@ -1267,6 +1267,22 @@ test "httpz: event stream" {
     try t.expectString("helloa message", res.body);
 }
 
+test "httpz: event stream sync" {
+    const stream = testStream(5992);
+    defer stream.close();
+    try stream.writeAll("GET /test/streamsync HTTP/1.1\r\nContent-Length: 0\r\n\r\n");
+
+    var res = testReadParsed(stream);
+    defer res.deinit();
+
+    try t.expectEqual(818, res.status);
+    try t.expectEqual(true, res.headers.get("Content-Length") == null);
+    try t.expectString("text/event-stream; charset=UTF-8", res.headers.get("Content-Type").?);
+    try t.expectString("no-cache", res.headers.get("Cache-Control").?);
+    try t.expectString("keep-alive", res.headers.get("Connection").?);
+    try t.expectString("helloa sync message", res.body);
+}
+
 test "httpz: keepalive" {
     const stream = testStream(5993);
     defer stream.close();
@@ -1609,7 +1625,7 @@ const TestDummyHandler = struct {
         const stream = try res.startEventStreamSync();
         const w = stream.writer();
         w.writeAll("hello") catch unreachable;
-        w.writeAll("a message") catch unreachable;
+        w.writeAll("a sync message") catch unreachable;
     }
 
     fn reqReader(req: *Request, res: *Response) !void {

--- a/src/response.zig
+++ b/src/response.zig
@@ -110,7 +110,7 @@ pub const Response = struct {
         self.headers.add(n, v);
     }
 
-    pub fn startEventStreamThread(self: *Response, ctx: anytype, comptime handler: fn (@TypeOf(ctx), std.net.Stream) void) !void {
+    pub fn startEventStream(self: *Response, ctx: anytype, comptime handler: fn (@TypeOf(ctx), std.net.Stream) void) !void {
         self.content_type = .EVENTS;
         self.headers.add("Cache-Control", "no-cache");
         self.headers.add("Connection", "keep-alive");
@@ -129,7 +129,7 @@ pub const Response = struct {
         thread.detach();
     }
 
-    pub fn startEventStream(self: *Response) !std.net.Stream {
+    pub fn startEventStreamSync(self: *Response) !std.net.Stream {
         self.content_type = .EVENTS;
         self.headers.add("Cache-Control", "no-cache");
         self.headers.add("Connection", "keep-alive");
@@ -137,11 +137,9 @@ pub const Response = struct {
         const conn = self.conn;
         const stream = conn.stream;
 
-        // Do a blocking write to get the header out first :)
-        // try conn.blockingMode();
+        // just keep it in non-blocking mode and return the stream
         const header_buf = try self.prepareHeader();
         try stream.writeAll(header_buf);
-        // try conn.nonblockingMode();
 
         self.disown();
         return stream;

--- a/src/response.zig
+++ b/src/response.zig
@@ -138,10 +138,10 @@ pub const Response = struct {
         const stream = conn.stream;
 
         // Do a blocking write to get the header out first :)
-        try conn.blockingMode();
+        // try conn.blockingMode();
         const header_buf = try self.prepareHeader();
         try stream.writeAll(header_buf);
-        try conn.nonblockingMode();
+        // try conn.nonblockingMode();
 
         self.disown();
         return stream;


### PR DESCRIPTION
keep the existing startEventStream()

add a variant startEventStreamSync() that still sets up the SSE headers, but just returns the stream rather than invoking a new thread

Works for me as is, and remains backwards compat

I think the old behaviour of creating a new thread is still pretty useful as is, and should remain the default 

Doing it using startEventStreamSync() should be a special case, because it infers the user will be doing something out of the ordinary like rolling their own coroutine handler, or over-speccing the number of threads on boot 
