### PR TITLE
fix middleware example document

### DIFF
--- a/examples/06_middleware.zig
+++ b/examples/06_middleware.zig
@@ -35,7 +35,7 @@ pub fn main() !void {
     router.middlewares = &.{logger};
 
     router.get("/", index, .{});
-    router.get("/other", other, .{ .middlewares = &.{} });
+    router.get("/other", other, .{ .middlewares = &.{}, .middleware_strategy = .replace });
 
     std.debug.print("listening http://localhost:{d}/\n", .{PORT});
 


### PR DESCRIPTION
I was confused when running [example 06](https://github.com/karlseguin/http.zig/blob/c16f21ebfc6d2896d50631cdc3ab6b4ece729361/examples/06_middleware.zig) because the `/other` route still goes through the logger middleware, which is different from the description in the comment.
After reviewing the source code, it seems that since the ["Rework middleware"](https://github.com/karlseguin/http.zig/commit/a5efb4e2) commit, the documentation has not been updated.