### PR TITLE
fix typo of 'pending'

### DIFF
--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -135,7 +135,7 @@ fn Worker(comptime F: anytype) type {
         // position in the queue to write to
         head: usize,
 
-        // pendind jobs
+        // pending jobs
         queue: []Args,
 
         buffer: []u8,


### PR DESCRIPTION
Hey, this is a small fix for 'pending' typo in thread_pool.zig.