### PR TITLE
fix(readme): update zig fetch command to support zsh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ listening http://localhost:8800/
 1) Add http.zig as a dependency in your `build.zig.zon`:
 
 ```bash
-zig fetch --save git+https://github.com/karlseguin/http.zig#master
+zig fetch --save "git+https://github.com/karlseguin/http.zig#master"
 ```
 
 2) In your `build.zig`, add the `httpz` module as a dependency you your program:


### PR DESCRIPTION
## Overview

Updated the installation instructions to ensure `zig fetch` works correctly in zsh by adding quotes around the dependency URL.

## Background

There's an error when installing the lib

```bash
λ zig fetch --save git+https://github.com/karlseguin/http.zig#master 
zsh: no matches found: git+https://github.com/karlseguin/http.zig#master
```

## Root cause

ZSH is interpreting the + or # characters in the URL as special characters, which might be causing issues


