### PR TITLE
Fix quick shutdown race

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,11 +22,13 @@ pub fn build(b: *std.Build) !void {
     }
 
     {
+        const enable_tsan = b.option(bool, "tsan", "Enable ThreadSanitizer");
         const test_filter = b.option([]const u8, "test-filter", "Filter for test");
         const tests = b.addTest(.{
             .root_source_file = b.path("src/httpz.zig"),
             .target = target,
             .optimize = optimize,
+            .sanitize_thread = enable_tsan,
             .filter = test_filter,
             .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
         });

--- a/build.zig
+++ b/build.zig
@@ -22,10 +22,12 @@ pub fn build(b: *std.Build) !void {
     }
 
     {
+        const test_filter = b.option([]const u8, "test-filter", "Filter for test");
         const tests = b.addTest(.{
             .root_source_file = b.path("src/httpz.zig"),
             .target = target,
             .optimize = optimize,
+            .filter = test_filter,
             .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
         });
         tests.linkLibC();

--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -417,6 +417,7 @@ pub fn Server(comptime H: type) type {
                     workers[i].stop();
                 };
 
+                var ready_sem = std.Thread.Semaphore{};
                 const threads = try self.arena.alloc(Thread, workers.len);
                 for (0..workers.len) |i| {
                     workers[i] = try Worker.init(allocator, self, &config);
@@ -424,8 +425,12 @@ pub fn Server(comptime H: type) type {
                         workers[i].stop();
                         workers[i].deinit();
                     }
-                    threads[i] = try Thread.spawn(.{}, Worker.run, .{ &workers[i], listener });
+                    threads[i] = try Thread.spawn(.{}, Worker.run, .{ &workers[i], listener, &ready_sem });
                     started += 1;
+                }
+
+                for (0..workers.len) |_| {
+                    ready_sem.wait();
                 }
 
                 // incase listenInNewThread was used and is waiting for us to start


### PR DESCRIPTION
- **Add a test filter flag**
- **Add option to enable thread sanitizer in tests**
- **Add semaphore to Worker.run to signal when it's done initializing**

The semaphore resolves the race condition identified in https://github.com/karlseguin/http.zig/issues/129
