### PR TITLE
fix deprecated things (#23096) and writergate (#24329) in 0.15 dev cycle

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,12 @@
     .fingerprint = 0x472add02ac73d53c,
     .dependencies = .{
         .metrics = .{
-            .url = "https://github.com/karlseguin/metrics.zig/archive/cf2797bcb3aea7e5cdaf4de39c5550c70796e7b1.tar.gz",
-            .hash = "N-V-__8AAHOzAQBh8wB371GN1DXTl1mKs8Rdqj0sJea0U4P7",
+            .url = "https://github.com/mrjbq7/metrics.zig/archive/fb1903f3c26111edae53d4c7515cfdd8f83f3f72.tar.gz",
+            .hash = "metrics-0.0.0-W7G4eEbHAQBWj_2429rqzSAkWQvClTInWMl8ghdpp4c7",
         },
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/7c3f1149bffcde1dec98dea88a442e2b580d750a.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdXNIAwCXG7oHBj4zc1CfmZcDeyR6hfTEOo8_YI4r",
+            .url = "https://github.com/mrjbq7/websocket.zig/archive/2466809e6990f67c011fd63ddd54dcc970dab2a8.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdfBVAwAGwgJ-g8NvRH1GFpoy7oJzeZatjHbObSCe",
         },
     },
 }

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -331,7 +331,7 @@ test "ThreadPool: batch add" {
                 tp.spawn(.{4});
             }
             while (tp.empty() == false) {
-                std.time.sleep(std.time.ns_per_ms);
+                std.Thread.sleep(std.time.ns_per_ms);
             }
             tp.stop();
             try t.expectEqual(10_000, testSum);
@@ -367,7 +367,7 @@ test "ThreadPool: small fuzz" {
         tp.spawn(.{3});
     }
     while (tp.empty() == false) {
-        std.time.sleep(std.time.ns_per_ms);
+        std.Thread.sleep(std.time.ns_per_ms);
     }
     tp.stop();
     try t.expectEqual(60_000, testSum);
@@ -403,7 +403,7 @@ test "ThreadPool: large fuzz" {
         tp.spawn(.{6});
     }
     while (tp.empty() == false) {
-        std.time.sleep(std.time.ns_per_ms);
+        std.Thread.sleep(std.time.ns_per_ms);
     }
     tp.stop();
     try t.expectEqual(210_000, testSum);
@@ -438,5 +438,5 @@ fn testIncr(c: u64, buf: []u8) void {
         else => unreachable,
     }
     // let the threadpool queue get backed up
-    std.time.sleep(std.time.ns_per_us * 20);
+    std.Thread.sleep(std.time.ns_per_us * 20);
 }

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -137,11 +137,11 @@ pub fn main() !void {
 }
 
 const Printer = struct {
-    out: std.fs.File.Writer,
+    out: std.fs.File.DeprecatedWriter,
 
     fn init() Printer {
         return .{
-            .out = std.io.getStdErr().writer(),
+            .out = std.fs.File.stderr().deprecatedWriter(),
         };
     }
 


### PR DESCRIPTION
See https://github.com/ziglang/zig/pull/23096 and https://github.com/ziglang/zig/pull/24329 for more info.

This should be reviewed a bit, I had to make some changes:

* to ``websocket.zig``, needed to expose ``KeyValue`` so that I could call ``createReply()``
* removed the ``directWriter()`` but i think that's okay it was only used in a test

Currently it uses my forks of ``websocket.zig`` and ``metrics.zig`` which have fixed the deprecations.