### PR TITLE
fix: do not attempt to close when not listening

### DIFF
--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -466,6 +466,11 @@ pub fn Server(comptime H: type) type {
             defer self._mut.unlock();
 
             for (self._workers) |*w| {
+                if (self._listener == null) {
+                    log.err("Cannot stop server, .listen() was never called", .{});
+                    break;
+                }
+
                 w.stop();
             }
 
@@ -927,6 +932,13 @@ test "httpz: quick shutdown" {
     const thrd = try server.listenInNewThread();
     server.stop();
     thrd.join();
+    server.deinit();
+}
+
+test "httpz: shutdown without listen" {
+    // Should not throw a .BADF (unreachable) error
+    var server = try Server(void).init(t.allocator, .{ .port = 6992 }, {});
+    server.stop();
     server.deinit();
 }
 


### PR DESCRIPTION
## Background

If you call `server.close()` in the defer block, but `.listen()` was never called - the underlying listener / file descriptor does not exist and posix will hit unreachable code here:

```sh
zig/std/posix.zig:4595:22: 0x100babc1b in kevent (http)
            .BADF => unreachable, // Always a race condition.
                     ^
```

Probably okay that it errors like that since you'll likely want to listen.. But perhaps a better log to know what's happening?