### PR TITLE
tsan: add buffer pool race test reproduction

### DIFF
--- a/src/buffer.zig
+++ b/src/buffer.zig
@@ -164,6 +164,29 @@ pub const Pool = struct {
 };
 
 const t = @import("t.zig");
+
+test "BufferPool race" {
+    if (comptime blockingMode()) return error.SkipZigTest;
+
+    var pool = try Pool.init(t.io, t.allocator, 1, 64);
+    defer pool.deinit();
+
+    const Ctx = struct {
+        fn worker(p: *Pool) void {
+            var i: usize = 0;
+            while (i < 500_000) : (i += 1) {
+                const buf = p.tryAlloc() orelse continue;
+                std.atomic.spinLoopHint();
+                p.release(buf);
+            }
+        }
+    };
+
+    var threads: [4]std.Thread = undefined;
+    for (&threads) |*thr| thr.* = try std.Thread.spawn(.{}, Ctx.worker, .{&pool});
+    for (&threads) |*thr| thr.join();
+}
+
 test "BufferPool" {
     var pool = try Pool.init(t.io, t.allocator, 2, 10);
     defer pool.deinit();


### PR DESCRIPTION
I run a load test on my application and tsan reported me:
```
monitoring-ochi-debug-1  | ==================
monitoring-ochi-debug-1  | WARNING: ThreadSanitizer: data race (pid=1)
monitoring-ochi-debug-1  |   Read of size 8 at 0xfffff5f60350 by thread T37:
monitoring-ochi-debug-1  |     #0 buffer.Pool.allocType /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/buffer.zig:114:31 (ochi+0x40b8ec)
monitoring-ochi-debug-1  |     #1 buffer.Pool.arenaAlloc /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/buffer.zig:84:30 (ochi+0x40bc44)
monitoring-ochi-debug-1  |     #2 request.State.prepareForBody /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/request.zig:1131:61 (ochi+0x40e95c)
monitoring-ochi-debug-1  |     #3 request.State.parseHeaders /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/request.zig:1016:59 (ochi+0x40fbd8)
monitoring-ochi-debug-1  |     #4 request.State.parse__anon_41648 /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/request.zig:772:38 (ochi+0x411038)
monitoring-ochi-debug-1  |     #5 worker.NonBlocking(*httpz.Server(*dispatch.Dispatcher),httpz.DummyWebsocketHandler).run /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/worker.zig:600:71 (ochi+0x41324c)
monitoring-ochi-debug-1  |     #6 Thread.callFn__anon_41278 /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:422:13 (ochi+0x4076b0)
monitoring-ochi-debug-1  |     #7 Thread.PosixThreadImpl.spawn__anon_41257.Instance.entryFn /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:752:30 (ochi+0x4074f4)
monitoring-ochi-debug-1  |
monitoring-ochi-debug-1  |   Previous write of size 8 at 0xfffff5f60350 by thread T6:
monitoring-ochi-debug-1  |     #0 buffer.Pool.release /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/buffer.zig:149:44 (ochi+0x4163ec)
monitoring-ochi-debug-1  |     #1 request.State.reset /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/request.zig:728:37 (ochi+0x415b2c)
monitoring-ochi-debug-1  |     #2 worker.HTTPConn.requestDone /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/worker.zig:1722:29 (ochi+0x4128d8)
monitoring-ochi-debug-1  |     #3 worker.NonBlocking(*httpz.Server(*dispatch.Dispatcher),httpz.DummyWebsocketHandler).processHTTPData /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/worker.zig:823:34 (ochi+0x4237ac)
monitoring-ochi-debug-1  |     #4 worker.NonBlocking(*httpz.Server(*dispatch.Dispatcher),httpz.DummyWebsocketHandler).processData /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/worker.zig:812:58 (ochi+0x422efc)
monitoring-ochi-debug-1  |     #5 thread_pool.Worker((function 'processData')).run /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/thread_pool.zig:251:17 (ochi+0x422d50)
monitoring-ochi-debug-1  |     #6 Thread.callFn__anon_46660 /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:422:13 (ochi+0x422910)
monitoring-ochi-debug-1  |     #7 Thread.PosixThreadImpl.spawn__anon_46642.Instance.entryFn /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:752:30 (ochi+0x422724)
monitoring-ochi-debug-1  |
monitoring-ochi-debug-1  |   Thread T37 (tid=44, running) created by main thread at:
monitoring-ochi-debug-1  |     #0 pthread_create /usr/local/zig-aarch64-linux-0.16.0/lib/libtsan/tsan_interceptors_posix.cpp:1090:3 (ochi+0xe25258)
monitoring-ochi-debug-1  |     #1 Thread.PosixThreadImpl.spawn__anon_41257 /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:770:33 (ochi+0x406aa0)
monitoring-ochi-debug-1  |     #2 Thread.spawn__anon_40702 /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:349:32 (ochi+0x406d28)
monitoring-ochi-debug-1  |     #3 httpz.Server(*dispatch.Dispatcher).listen /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/httpz.zig:428:50 (ochi+0x402b9c)
monitoring-ochi-debug-1  |     #4 server.startServer /app/src/server.zig:76:18 (ochi+0x403a2c)
monitoring-ochi-debug-1  |     #5 main.main /app/src/main.zig:57:27 (ochi+0x4041c8)
monitoring-ochi-debug-1  |     #6 start.callMain /usr/local/zig-aarch64-linux-0.16.0/lib/std/start.zig:698:59 (ochi+0x40476c)
monitoring-ochi-debug-1  |     #7 start.callMainWithArgs /usr/local/zig-aarch64-linux-0.16.0/lib/std/start.zig:638:20 (ochi+0x40476c)
monitoring-ochi-debug-1  |     #8 main /usr/local/zig-aarch64-linux-0.16.0/lib/std/start.zig:663:28 (ochi+0x40476c)
monitoring-ochi-debug-1  |
monitoring-ochi-debug-1  |   Thread T6 (tid=13, running) created by main thread at:
monitoring-ochi-debug-1  |     #0 pthread_create /usr/local/zig-aarch64-linux-0.16.0/lib/libtsan/tsan_interceptors_posix.cpp:1090:3 (ochi+0xe25258)
monitoring-ochi-debug-1  |     #1 Thread.PosixThreadImpl.spawn__anon_46642 /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:770:33 (ochi+0x422184)
monitoring-ochi-debug-1  |     #2 Thread.spawn__anon_40678 /usr/local/zig-aarch64-linux-0.16.0/lib/std/Thread.zig:349:32 (ochi+0x42240c)
monitoring-ochi-debug-1  |     #3 thread_pool.ThreadPool((function 'processData')).init /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/thread_pool.zig:56:46 (ochi+0x400e48)
monitoring-ochi-debug-1  |     #4 worker.NonBlocking(*httpz.Server(*dispatch.Dispatcher),httpz.DummyWebsocketHandler).init /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/worker.zig:466:70 (ochi+0x40180c)
monitoring-ochi-debug-1  |     #5 httpz.Server(*dispatch.Dispatcher).listen /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/httpz.zig:423:49 (ochi+0x4028a0)
monitoring-ochi-debug-1  |     #6 server.startServer /app/src/server.zig:76:18 (ochi+0x403a2c)
monitoring-ochi-debug-1  |     #7 main.main /app/src/main.zig:57:27 (ochi+0x4041c8)
monitoring-ochi-debug-1  |     #8 start.callMain /usr/local/zig-aarch64-linux-0.16.0/lib/std/start.zig:698:59 (ochi+0x40476c)
monitoring-ochi-debug-1  |     #9 start.callMainWithArgs /usr/local/zig-aarch64-linux-0.16.0/lib/std/start.zig:638:20 (ochi+0x40476c)
monitoring-ochi-debug-1  |     #10 main /usr/local/zig-aarch64-linux-0.16.0/lib/std/start.zig:663:28 (ochi+0x40476c)
monitoring-ochi-debug-1  |
monitoring-ochi-debug-1  | SUMMARY: ThreadSanitizer: data race /app/zig-pkg/httpz-0.0.0-PNVzrLjJCAD37S0CcrXpsjSqr86hVjK0rsALTDJ98AAJ/src/buffer.zig:114:31 in buffer.Pool.allocType
monitoring-ochi-debug-1  | ==================
```

so I added a race reproduction on the buffer pool to see what's the catch.
and yes, it crashed:

```
================================================================================
panic running "BufferPool race"
================================================================================
thread 640907668 panic: index out of bounds: index 1, len 1
/Users/d/projects/http.zig/src/buffer.zig:148:29: 0x104e340e3 in release (test)
                self.buffers[available] = buffer;
                            ^
/Users/d/projects/http.zig/src/buffer.zig:194:26: 0x104e7211b in worker (test)
                p.release(buf);
                         ^
/opt/homebrew/Cellar/zig/0.16.0_1/lib/zig/std/Thread.zig:422:13: 0x104e72047 in callFn__anon_67903 (test)
            @call(.auto, f, args);
            ^
/opt/homebrew/Cellar/zig/0.16.0_1/lib/zig/std/Thread.zig:752:30: 0x104e71ee3 in entryFn (test)
                return callFn(f, args_ptr.*);
                             ^
???:?:?: 0x183eb7bc7 in __pthread_cond_wait (/usr/lib/system/libsystem_pthread.dylib)
???:?:?: 0x183eb2b7f in _pthread_cond_broadcast (/usr/lib/system/libsystem_pthread.dylib)
```