### PR TITLE
posix：通过SetHandleInformation在Windows上实现CLOEXEC

### DIFF
--- a/src/posix.zig
+++ b/src/posix.zig
@@ -87,7 +87,11 @@ pub fn socket(domain: u32, socket_type: u32, protocol: u32) !socket_t {
 fn setSockFlags(sock: socket_t, flags: u32) !void {
     if ((flags & CLOEXEC) != 0) {
         if (native_os == .windows) {
-            // TODO: Find out if this is supported for sockets
+            // Windows: disable handle inheritance. This prevents child
+            // processes from inheriting the socket, equivalent to FD_CLOEXEC.
+            // Socket handles are HANDLE objects in Windows NT, so
+            // SetHandleInformation works on them.
+            try windows.setNoInherit(@ptrCast(sock));
         } else {
             var fd_flags = fcntl(sock, F.GETFD, 0) catch |err| switch (err) {
                 error.FileBusy => unreachable,
@@ -116,7 +120,11 @@ fn setSockFlags(sock: socket_t, flags: u32) !void {
                     .WSANOTINITIALISED => unreachable,
                     .WSAENETDOWN => return error.NetworkSubsystemFailed,
                     .WSAENOTSOCK => return error.FileDescriptorNotASocket,
-                    // TODO: handle more errors
+                    .WSAEINVAL => return error.Unexpected,
+                    .WSAEFAULT,
+                    .WSAEOPNOTSUPP,
+                    .WSAEINPROGRESS,
+                    => unreachable,
                     else => |err| return windows.unexpectedWSAError(err),
                 }
             }

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -294,6 +294,21 @@ const OVERLAPPED = extern struct {
     hEvent: ?HANDLE,
 };
 
+pub const HANDLE_FLAG_INHERIT = 1;
+pub const HANDLE_FLAG_PROTECT_FROM_CLOSE = 2;
+
+/// Disables handle inheritance for the given handle (Windows equivalent of
+/// FD_CLOEXEC). Works on socket handles as well as regular file handles.
+pub fn setNoInherit(handle: HANDLE) !void {
+    if (kernel32.SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0) == .FALSE) {
+        switch (GetLastError()) {
+            .INVALID_HANDLE => return error.Unexpected,
+            .ACCESS_DENIED => return error.AccessDenied,
+            else => |err| return std_windows.unexpectedError(err),
+        }
+    }
+}
+
 /// kernel32 was severely trimmed in Zig 0.16, so re-declare the few entry
 /// points we need.
 const kernel32 = struct {
@@ -311,5 +326,11 @@ const kernel32 = struct {
         nNumberOfBytesToWrite: DWORD,
         lpNumberOfBytesWritten: ?*DWORD,
         lpOverlapped: ?*OVERLAPPED,
+    ) callconv(.winapi) BOOL;
+
+    pub extern "kernel32" fn SetHandleInformation(
+        hObject: HANDLE,
+        dwMask: DWORD,
+        dwFlags: DWORD,
     ) callconv(.winapi) BOOL;
 };


### PR DESCRIPTION
Replace two TODOs in setSockFlags:

- CLOEXEC: Windows socket handles created by accept() did not have close-on-exec semantics.  Fixed by calling SetHandleInformation with HANDLE_FLAG_INHERIT=0 — the Windows equivalent of FD_CLOEXEC. (socket() already handled this via WSA_FLAG_NO_HANDLE_INHERIT.)

- NONBLOCK: replace the generic WSA error catch-all with specific handling for WSAEINVAL (returns error), WSAEFAULT / WSAEOPNOTSUPP / WSAEINPROGRESS (all unreachable for FIONBIO).

Also add constants HANDLE_FLAG_INHERIT, HANDLE_FLAG_PROTECT_FROM_CLOSE and a setNoInherit() helper to windows.zig.