### PR TITLE
Fix use-after-free: defer connection teardown past the harvested event batch

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -551,6 +551,9 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             };
             ready_sem.post(io);
             defer self.websocket.shutdown();
+            // The graveyard may be non-empty when the loop exits via .shutdown
+            // mid-batch; release before deinit so pools account for everything.
+            defer self.reapGraveyard();
 
             var now = timestamp(io);
             var last_timeout = now;
@@ -586,59 +589,73 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                             };
                         },
                         .signal => self.processSignal(&closed_conn),
-                        .recv => |conn| switch (conn.protocol) {
-                            .http => |http_conn| {
-                                switch (http_conn.getState()) {
-                                    .request, .keepalive => {},
-                                    .active, .handover => {
-                                        // we need to finish whatever we're doing
-                                        // before we can process more data (i.e. if
-                                        // the connection is being upgrade to websocket,
-                                        // this will be a websocket message.)
+                        .recv => |conn| {
+                            if (conn.dead) {
+                                // This conn was retired earlier in this same
+                                // harvested batch (e.g. by a handover/disown
+                                // signal processed before this event). Its
+                                // memory is only valid because reaping is
+                                // deferred until the batch completes. Skip.
+                                continue;
+                            }
+                            switch (conn.protocol) {
+                                .http => |http_conn| {
+                                    switch (http_conn.getState()) {
+                                        .request, .keepalive => {},
+                                        .active, .handover => {
+                                            // we need to finish whatever we're doing
+                                            // before we can process more data (i.e. if
+                                            // the connection is being upgrade to websocket,
+                                            // this will be a websocket message.)
+                                            continue;
+                                        },
+                                    }
+
+                                    // At this point, the connection is either in
+                                    // keepalive or request. Either way, we know no
+                                    // other thread is accessing the connection, so we
+                                    // can access _state directly.
+
+                                    const stream = http_conn.stream;
+                                    var reader = stream.reader(io, &.{}); // Request.State does its own buffering
+                                    const done = http_conn.req_state.parse(http_conn, &reader.interface) catch |err| {
+                                        // maybe a write fail or something, doesn't matter, we're closing the connection
+                                        requestError(http_conn, reader.err orelse err) catch {};
+
+                                        // impossible to fail when false is passed
+                                        http_conn.requestDone(self.retain_allocated_bytes, false) catch unreachable;
+                                        conn.close();
+                                        self.disown(conn);
+                                        if (self.full) self.enableListener(listener);
                                         continue;
-                                    },
-                                }
+                                    };
 
-                                // At this point, the connection is either in
-                                // keepalive or request. Either way, we know no
-                                // other thread is accessing the connection, so we
-                                // can access _state directly.
+                                    if (done == false) {
+                                        self.swapList(conn, .request);
+                                        continue;
+                                    }
 
-                                const stream = http_conn.stream;
-                                var reader = stream.reader(io, &.{}); // Request.State does its own buffering
-                                const done = http_conn.req_state.parse(http_conn, &reader.interface) catch |err| {
-                                    // maybe a write fail or something, doesn't matter, we're closing the connection
-                                    requestError(http_conn, reader.err orelse err) catch {};
-
-                                    // impossible to fail when false is passed
-                                    http_conn.requestDone(self.retain_allocated_bytes, false) catch unreachable;
-                                    conn.close();
-                                    self.disown(conn);
-                                    if (self.full) self.enableListener(listener);
-                                    continue;
-                                };
-
-                                if (done == false) {
-                                    self.swapList(conn, .request);
-                                    continue;
-                                }
-
-                                self.swapList(conn, .active);
-                                thread_pool.spawn(.{ self, now, conn });
-                            },
-                            .websocket => {
-                                if (conn.acquireProcessing() == false) {
-                                    // Connection is already being processed. We need
-                                    // to wait for the current processing to complete.
-                                    // See the processing field in Conn
-                                    continue;
-                                }
-                                thread_pool.spawn(.{ self, now, conn });
-                            },
+                                    self.swapList(conn, .active);
+                                    thread_pool.spawn(.{ self, now, conn });
+                                },
+                                .websocket => {
+                                    if (conn.acquireProcessing() == false) {
+                                        // Connection is already being processed. We need
+                                        // to wait for the current processing to complete.
+                                        // See the processing field in Conn
+                                        continue;
+                                    }
+                                    thread_pool.spawn(.{ self, now, conn });
+                                },
+                            }
                         },
                         .shutdown => return,
                     }
                 }
+
+                // The harvested batch is fully processed; it is now safe to
+                // release the memory of connections retired during it.
+                self.reapGraveyard();
 
                 const batch_size = thread_pool.batch_size;
                 if (batch_size > 0) {

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -408,6 +408,14 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
         // that alone) and the worker thread will process it.
         handover_list: ConcurrentList(Conn(WSH)),
 
+        // Connections retired mid-batch: removed from their state list, fd no
+        // longer monitored, but memory NOT yet released — the harvested event
+        // batch currently being processed may still hold pointers to them
+        // (epoll_ctl(DEL)/close() do not retract already-harvested events).
+        // Only the worker thread touches this. reapGraveyard() releases the
+        // entries once the batch is fully processed.
+        graveyard: List(Conn(WSH)),
+
         // A pool of HTTPConn objects. The pool maintains a configured min # of these.
         // An HTTPConn is relatively expensive, since we pre-allocate all types
         // of things (a Request.State and Response.State).
@@ -488,6 +496,7 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 .request_list = .{},
                 .handover_list = .{},
                 .keepalive_list = .{},
+                .graveyard = .{},
                 .buffer_pool = buffer_pool,
                 .conn_mem_pool = conn_mem_pool,
                 .http_conn_pool = http_conn_pool,
@@ -1506,6 +1515,13 @@ pub fn Conn(comptime WSH: type) type {
         // wait calls as we're switching to DISPATCH. So this guard is there just
         // for thar narrow window.
         processing: bool = false,
+
+        // Set when the connection is retired (graveyarded) while a harvested
+        // event batch may still hold a reference to it. The event loop checks
+        // this before processing a .recv event so a stale event for a retired
+        // connection no-ops. accept() re-initializes the whole struct on
+        // node reuse, which resets this to false.
+        dead: bool = false,
 
         const Self = @This();
 

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -789,8 +789,9 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 switch (http_conn.handover) {
                     .close, .unknown => {
                         closed_bool.* = true;
-                        // http handler already closed the socket
-                        self.disown(conn);
+                        // http handler already closed the socket. The conn came
+                        // from the snapshotted handover list — already detached.
+                        self.disownDetached(conn);
                     },
                     .disown => {
                         // When res.disown() was called, we immediately removed
@@ -799,14 +800,14 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                         // before we get back here.
                         // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
                         closed_bool.* = true;
-                        self.disown(conn);
+                        self.disownDetached(conn);
                     },
                     .websocket => |ptr| {
                         if (comptime WSH == httpz.DummyWebsocketHandler) {
                             std.debug.print("Your httpz handler must have a `WebsocketHandler` declaration. This must be the same type passed to `httpz.upgradeWebsocket`. Closing the connection.\n", .{});
                             closed_bool.* = true;
                             conn.close();
-                            self.disown(conn);
+                            self.disownDetached(conn);
                             continue;
                         }
 
@@ -819,7 +820,7 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                             metrics.internalError();
                             closed_bool.* = true;
                             conn.close();
-                            self.disown(conn);
+                            self.disownDetached(conn);
                             continue;
                         };
                     },
@@ -895,32 +896,30 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             }
         }
 
-        // Retire a connection: detach it from its state list, mark it dead and
-        // queue it on the graveyard. Memory is NOT released here — an event
-        // referencing this conn may already have been harvested into the batch
-        // currently being processed (epoll_ctl(DEL)/close() do not retract
-        // harvested events). reapGraveyard() releases it once the batch is done.
+        // Retire a connection that is still linked in its state list (the recv
+        // parse-error path and accept's errdefer). Connections that are already
+        // detached — processSignal's snapshotted handover conns and
+        // closeList's timed-out splice — must use disownDetached instead:
+        // removing them here through their stale prev/next pointers corrupts
+        // the live list.
         fn disown(self: *Self, conn: *Conn(WSH)) void {
-            std.debug.assert(!conn.dead);
-            switch (conn.protocol) {
-                .http => |http_conn| switch (http_conn._state) {
-                    .request => self.request_list.remove(conn),
-                    // .handover connections only reach disown from
-                    // processSignal, which snapshots and re-initializes the
-                    // handover list — they are already detached. Removing them
-                    // from the live list here (with their stale snapshot
-                    // prev/next pointers) corrupts it when a thread-pool
-                    // thread has concurrently inserted a new entry.
-                    .handover => {},
-                    .keepalive => self.keepalive_list.remove(self.io, conn),
-                    .active => unreachable,
-                },
-                // processSignal's websocket-handover failure path: the
-                // HTTPConn was already released back to its pool and the
-                // protocol switched, and the conn came from the snapshotted
-                // handover list, so it is already detached.
-                .websocket => {},
+            const http_conn = conn.protocol.http;
+            switch (http_conn._state) {
+                .request => self.request_list.remove(conn),
+                .keepalive => self.keepalive_list.remove(self.io, conn),
+                .handover, .active => unreachable,
             }
+            self.disownDetached(conn);
+        }
+
+        // Retire a connection: mark it dead and queue it on the graveyard. The
+        // conn must no longer be in any state list. Memory is NOT released
+        // here — an event referencing this conn may already have been
+        // harvested into the batch currently being processed
+        // (epoll_ctl(DEL)/close() do not retract harvested events).
+        // reapGraveyard() releases it once the batch is done.
+        fn disownDetached(self: *Self, conn: *Conn(WSH)) void {
+            std.debug.assert(!conn.dead);
             self.len -= 1;
             conn.dead = true;
             self.graveyard.insert(conn);
@@ -993,6 +992,9 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             while (conn) |c| {
                 const timeout = c.protocol.http.timeout;
                 if (timeout > now) {
+                    // c becomes the new head; its prev must not dangle into
+                    // the spliced-out timed_out chain.
+                    c.prev = null;
                     list.head = c;
                     return .{ timed_out, count, timeout };
                 }
@@ -1010,7 +1012,10 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             while (conn) |c| {
                 conn = c.next;
                 c.close();
-                self.disown(c);
+                // collectTimedOut already spliced these conns out of the live
+                // list — use disownDetached to avoid list-removing them again
+                // through their rewritten prev/next pointers.
+                self.disownDetached(c);
             }
         }
 

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -878,18 +878,53 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             }
         }
 
+        // Retire a connection: detach it from its state list, mark it dead and
+        // queue it on the graveyard. Memory is NOT released here — an event
+        // referencing this conn may already have been harvested into the batch
+        // currently being processed (epoll_ctl(DEL)/close() do not retract
+        // harvested events). reapGraveyard() releases it once the batch is done.
         fn disown(self: *Self, conn: *Conn(WSH)) void {
-            const io = self.io;
-            const http_conn = conn.protocol.http;
-            switch (http_conn._state) {
-                .request => self.request_list.remove(conn),
-                .handover => self.handover_list.remove(io, conn),
-                .keepalive => self.keepalive_list.remove(io, conn),
-                .active => unreachable,
+            std.debug.assert(!conn.dead);
+            switch (conn.protocol) {
+                .http => |http_conn| switch (http_conn._state) {
+                    .request => self.request_list.remove(conn),
+                    // .handover connections only reach disown from
+                    // processSignal, which snapshots and re-initializes the
+                    // handover list — they are already detached. Removing them
+                    // from the live list here (with their stale snapshot
+                    // prev/next pointers) corrupts it when a thread-pool
+                    // thread has concurrently inserted a new entry.
+                    .handover => {},
+                    .keepalive => self.keepalive_list.remove(self.io, conn),
+                    .active => unreachable,
+                },
+                // processSignal's websocket-handover failure path: the
+                // HTTPConn was already released back to its pool and the
+                // protocol switched, and the conn came from the snapshotted
+                // handover list, so it is already detached.
+                .websocket => {},
             }
             self.len -= 1;
-            self.http_conn_pool.release(http_conn);
-            self.conn_mem_pool.destroy(conn);
+            conn.dead = true;
+            self.graveyard.insert(conn);
+        }
+
+        // Release the memory of all retired connections. Must only run when no
+        // harvested event batch is in flight: between loop.wait() calls, or
+        // after the run loop has exited.
+        fn reapGraveyard(self: *Self) void {
+            var c = self.graveyard.head;
+            while (c) |conn| {
+                c = conn.next;
+                switch (conn.protocol) {
+                    .http => |http_conn| self.http_conn_pool.release(http_conn),
+                    // The HTTPConn was already released when the protocol
+                    // switched to websocket.
+                    .websocket => {},
+                }
+                self.conn_mem_pool.destroy(conn);
+            }
+            self.graveyard = .{};
         }
 
         // Enforces timeouts, and returns when the next timeout should be checked.


### PR DESCRIPTION
## The bug

On Linux/epoll (and in principle kqueue), the NonBlocking worker frees a connection's memory while the event batch harvested by `loop.wait()` can still contain an event pointing at it. `loop.wait()` copies up to 128 events into userspace, each carrying a raw `*Conn` (`data.ptr = @intFromPtr(conn)`); `EPOLL_CTL_DEL`/`close()` do **not** retract events already harvested. So a batch shaped `[signal: handover/disown(X), …, recv(X)]` dereferences freed memory when it reaches `recv(X)` → `http_conn.getState()` reads `&_state` of a destroyed `HTTPConn`.

In a downstream service this is a reproducible whole-server segfault (crash address `0x2f8` = the `_state` offset) under mass keepalive disconnects — fed by both the `res.disown()` SSE handoff and the abrupt-disconnect close path. The existing mitigations (closing the fd in `processHTTPData` to drop it from epoll; the `accept()` comment about not closing keepalive conns mid-loop) address other interleavings of this class but not the already-harvested-batch window.

## The fix

Connections now **retire** instead of being destroyed mid-batch: `disown` detaches the conn from its state list, sets a new `Conn.dead` flag, and pushes it onto a worker-local `graveyard`. `reapGraveyard()` performs the actual `http_conn_pool.release` + `conn_mem_pool.destroy` only after the harvested batch is fully processed (and via `defer` on the run loop's `.shutdown` exit). The `.recv` arm skips `conn.dead` events, so a stale harvested event for a retired conn no-ops while its memory stays valid until end-of-batch.

Deferring the **pool release** matters as much as the `destroy`: releasing the `HTTPConn` back to its pool mid-batch would let `accept()` in the same batch reuse it — the same UAF in different clothes.

## Two further teardown bugs fixed by the same rewrite

1. **Live handover-list corruption.** `processSignal` snapshots the handover list and re-initializes it (`hl.inner = .{}`), then walks the snapshot calling `disown`. Those conns are already detached, but `disown` still called `handover_list.remove` on the *live* list using each node's stale snapshot `prev`/`next`. With a concurrent thread-pool `swapList(conn, .handover)` insert, that can overwrite the live head and lose the inserted connection (its handover never runs, `len` never decrements). Fixed by routing already-detached conns through a `disownDetached` that skips the list-remove.

2. **Timed-out splice corruption.** `collectTimedOut` splices expired conns out of the live list (advancing `list.head`, relinking the expired nodes into a `timed_out` list via `insert`, which rewrites their `prev`/`next`). `closeList` then ran them back through `disown`'s list-remove — and the first expired node (`prev == null`) set `list.head` to a pointer into the `timed_out` chain, **orphaning every surviving connection** (they never time out again, `len` leaks, and a later `swapList` on a survivor writes through its stale `prev` into freed memory). The survivor that becomes the new head also kept a stale `prev` into the spliced-out chain. Fixed: `closeList` uses `disownDetached`, and `collectTimedOut` clears the new head's `prev`.

So `disown` now handles only conns still linked in their state list (the recv parse-error path and `accept`'s errdefer; `.handover`/`.active` are `unreachable`), and `disownDetached` retires already-detached conns (the `processSignal` snapshot walk and the `closeList` timed-out walk).

## Testing

`zig build test` stays green (125/125, no allocator leak report). I couldn't make the harvested-batch race deterministic from the public API (it needs a specific epoll batch composition), so there's no new unit test — happy to add one if you can suggest a seam into the worker's event loop. Verified externally: the downstream service's integration suite ran 30/30 clean Linux iterations on the patched build, and the `swapList`-on-freed-mutex symptom of bug 2 reproduced on the unpatched build under disconnect-churn stress.

## Not addressed here

A separate teardown race exists where a thread-pool task calls `processHTTPData` → `swapList(conn, .keepalive)` on a conn the event loop is concurrently tearing down (panic: `switch on corrupt value` at the conn mutex). It reproduces on master too and is independent of this batch-harvest fix; I'm still root-causing it and didn't want to fold an unverified change into this PR.