### PR TITLE
Fix lost websocket read by releasing processing before re-arm

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -851,16 +851,25 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
         }
 
         pub fn processWebsocketData(self: *Self, conn: *Conn(WSH), thread_buf: []u8, hc: *ws.HandlerConn(WSH)) void {
-            defer conn.releaseProcessing();
-
             var ws_conn = &hc.conn;
             const success = self.websocket.worker.dataAvailable(hc, thread_buf);
             if (success == false) {
                 ws_conn.close(.{ .code = 4997, .reason = "wsz" }) catch {};
                 self.websocket.cleanupConn(hc);
+                conn.releaseProcessing();
             } else if (ws_conn.isClosed()) {
                 self.websocket.cleanupConn(hc);
+                conn.releaseProcessing();
             } else {
+                // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
+                // while still holding `processing` loses a read that arrives in the
+                // window between the re-arm and the release: the event loop sees the
+                // connection as busy (acquireProcessing fails) and the one-shot arming
+                // is consumed, so the read is dropped and the connection hangs / leaks
+                // (CLOSE_WAIT). Releasing first means a read arriving after this
+                // dispatches a fresh worker, and a read already buffered is re-reported
+                // when rearmRead arms the readable fd.
+                conn.releaseProcessing();
                 self.loop.rearmRead(conn) catch |err| {
                     log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
                     ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};


### PR DESCRIPTION
Fixes a lost EPOLLONESHOT websocket read that leaks connections (CLOSE_WAIT) and hangs clients under load.

With EPOLLONESHOT, re-arming the fd while still holding `processing` loses a read that arrives in the window between the re-arm and the release: the event loop sees the connection as busy (acquireProcessing fails) and the one-shot arming is consumed, so the read is dropped.

Fix: release `processing` before re-arming. A read arriving after the release dispatches a fresh worker normally, and a read already buffered is re-reported when rearmRead arms the readable fd (EPOLL_CTL_MOD on a readable fd re-fires; kqueue EV_ADD likewise). No extra state.

Verified with a deterministic repro: injecting a 5ms delay into the window and driving a NIP-42 request/response flow, the old ordering hangs 10/10 while this passes 0/10; a 2-core statistical A/B was 3/60 hung (old) vs 0/60 (this).

(Updated from an earlier version that used a pending flag; per review, the reorder alone is sufficient.)