### PR TITLE
Bump websocket.zig to include the TLS read-timeout fix

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "metrics-0.0.0-W7G4eIegAQD4XxA9Co7Atbw59u_2zvxYf406AZuoAHPM",
         },
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/6d309f7a9790030f2fc070323b5defc64a15c13b.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdV_aBACU9pGuvrTQ2z8uxz_Sp8JnJgQaiGKQIx1l",
+            .url = "https://github.com/karlseguin/websocket.zig/archive/99df0d3533a41cbcd5ff59b9af68bbfe6169cc62.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdangBAAgWPap_MVU6Nk4rj3GT3xuJuF0IIv8HN6G",
         },
         // .websocket = .{ .path = "../websocket.zig" },
     },


### PR DESCRIPTION
Bumps the pinned `websocket.zig` from `6d309f7` to the current master (`99df0d3`), which includes #103.

That fix makes the websocket client poll the fd for read readiness instead of relying on `SO_RCVTIMEO`. Without it, a read timeout on a TLS (`wss://`) connection produces a socket `EAGAIN` that `std.crypto.tls`'s reader treats as a programmer bug and panics on in debug builds (and tears the connection down in release). Since http.zig vendors this websocket version, httpz servers/clients on the older pin inherit that crash; this picks up the fix.

One-line dependency bump, no code change.