### PR TITLE
worker: fix recv/disown use-after-free by deferring signal handling

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -568,6 +568,16 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 now = timestamp(io);
                 var closed_conn = false;
 
+                // Defer signal handling (which disowns/frees handed-over
+                // connections) until the whole event batch is drained. epoll can
+                // return a .signal and a .recv for the same connection in one
+                // batch; processing the signal first would free the connection,
+                // and the later .recv would then dereference freed memory in
+                // getState(). By deferring, every .recv runs while its connection
+                // is still alive, sees the .handover state set before the signal,
+                // and skips it; the free happens safely afterward.
+                var has_signal = false;
+
                 while (it.next()) |event| {
                     switch (event) {
                         .accept => self.accept(listener, now) catch |err| {
@@ -576,7 +586,7 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                                 log.err("Failed to do a mini recovery sleep: {}", .{err2});
                             };
                         },
-                        .signal => self.processSignal(&closed_conn),
+                        .signal => has_signal = true,
                         .recv => |conn| switch (conn.protocol) {
                             .http => |http_conn| {
                                 switch (http_conn.getState()) {
@@ -630,6 +640,10 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                         .shutdown => return,
                     }
                 }
+
+                // Now that every .recv in this batch has been handled, it is safe
+                // to disown/free the connections handed over since the last batch.
+                if (has_signal) self.processSignal(&closed_conn);
 
                 const batch_size = thread_pool.batch_size;
                 if (batch_size > 0) {


### PR DESCRIPTION
## Problem

Under sustained load a worker segfaults in `getState()`:

```
Segmentation fault at address 0x2f8
src/worker.zig:1679 in getState   (@atomicLoad(&self._state), self == null)
```

In one `loop.wait` batch the worker can receive both a `.signal` and a `.recv` for the same connection. The `.signal` branch runs `processSignal` -> `disown`, which frees the connection (`http_conn_pool.release(http_conn)` + `conn_mem_pool.destroy(conn)`). The later `.recv` for that same connection then dereferences the freed memory via `http_conn.getState()`.

This is the race the existing comment in the `.close`/`.unknown` recv path warns about ("you'd get a segfault if the signal cleared the connection, and then in recv we'd try to call conn.getState() after the signal"); that mitigation only covers the recv-initiated close, not a `.signal` and a `.recv` landing in the same batch.

## Fix

Defer `processSignal` until the whole event batch is drained. Every `.recv` then runs while its connection is still alive; if the connection was handed over it is already in `.handover` state (set by `swapList` before the worker thread signals), so the existing `.active, .handover => continue` guard skips it. The disown/free happens after the batch, when no `.recv` can reference it. Minimal, no lifecycle restructuring.

## Validation

Found via a ReleaseSafe build of a relay that segfaulted every ~2.5-3h under real inbound traffic. With this change it ran 13h+ under the same load with no crash. Library tests and a downstream integration suite pass.