### PR TITLE
worker: stop thread pool before deinit to fix shutdown use-after-free

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -504,6 +504,11 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             self.websocket.deinit();
             allocator.destroy(self.websocket);
 
+            // Join in-flight handlers before freeing the pool. run() only stops
+            // the event loop, so a handler can still be mid-callback here; without
+            // this, deinit frees its stack/buffer (and the caller proceeds to tear
+            // down resources the handler is still using) -> use-after-free.
+            self.thread_pool.stop();
             self.thread_pool.deinit();
 
             self.shutdownList(&self.request_list);


### PR DESCRIPTION
## Problem

In non-blocking mode, `NonBlocking(...).deinit()` calls `self.thread_pool.deinit()` (which is just `arena.deinit()`) without first calling `thread_pool.stop()`. `Worker.stop()` only stops the event loop (`self.loop.stop()`), and `run()` never stops the pool either (unlike the blocking worker, whose `listen()` calls `thread_pool.stop()` before returning). So on shutdown a handler thread can still be mid-callback when `deinit()` frees the arena that owns its stack and buffer.

The result is a use-after-free: the freed handler keeps running, and the application proceeds through its own teardown to release resources the handler is still touching. We hit this in production (a relay) as a SIGSEGV inside a query handler when SIGTERM landed during an in-flight request, the worker arena and the storage handle were both torn down while the handler was still iterating.

## Fix

Call `thread_pool.stop()` before `thread_pool.deinit()` in the non-blocking worker's `deinit()`. By `deinit()` time the event loop has already returned, so `stop()` simply joins the handler threads (it wakes idle workers via the read cond and waits for any in-flight callback to finish), guaranteeing no handler is running when the arena is freed. `stop()` is idempotent, so this is safe whether or not it was already called elsewhere.

One line plus a comment. Builds clean on 0.16.