### PR TITLE
worker: remove fd from epoll on the loop thread before recycling Conn

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -782,7 +782,13 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 switch (http_conn.handover) {
                     .close, .unknown => {
                         closed_bool.* = true;
-                        // http handler already closed the socket
+                        // Remove from the event loop and close here, on the loop
+                        // thread, before disown() recycles the Conn. The fd is
+                        // still open (processHTTPData no longer closes it on the
+                        // worker thread), so the DEL is valid and no later batch
+                        // can deliver a .recv for the freed Conn.
+                        loop.remove(conn);
+                        conn.close();
                         self.disown(conn);
                     },
                     .disown => {
@@ -853,15 +859,15 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                     return;
                 },
                 .close, .unknown => {
-                    // We _have_ to close the connection here in order to avoid
-                    // a bad race condition. By closing it here, we [automatically]
-                    // remove the connection from epoll/kqueue, which ensures that
-                    // in a single loop through ready-event we won't process both
-                    // a signal and a recv message.
-                    // If we don't do this here, then you'd get a segfault if
-                    // the signal cleared the connetion, and then in recv we'd
-                    // try to call conn.getState() after the signal.
-                    posix.close(http_conn.stream.socket.handle);
+                    // Closing the socket (which removes it from epoll/kqueue) is
+                    // deferred to processSignal on the event-loop thread. Closing
+                    // here, on a worker thread, raced epoll_wait: the fd could
+                    // stay armed past the point where disown() recycled the Conn,
+                    // so a later batch delivered a .recv carrying a pointer to
+                    // freed memory (getState on a null/recycled HTTPConn). The
+                    // signal-vs-recv-in-one-batch case this used to guard against
+                    // is now handled by deferring signal processing to the end of
+                    // the event batch plus the getState() .handover check in recv.
                 },
                 .websocket, .disown => {},
             }
@@ -1134,6 +1140,17 @@ fn KQueue(comptime WSH: type) type {
             try self.change(conn.getSocket(), @intFromPtr(conn), posix.system.EVFILT.READ, posix.system.EV.ADD | posix.system.EV.ENABLE, 0);
         }
 
+        fn remove(self: *Self, conn: *Conn(WSH)) void {
+            _ = posix.kevent(self.fd, &.{.{
+                .ident = @intCast(conn.getSocket()),
+                .filter = posix.system.EVFILT.READ,
+                .flags = posix.system.EV.DELETE,
+                .fflags = 0,
+                .data = 0,
+                .udata = 0,
+            }}, &.{}, null) catch {};
+        }
+
         fn rearmRead(self: *Self, conn: *Conn(WSH)) !void {
             // called from the worker thread, can't use change_buffer
             // must remove then re-add for macOS
@@ -1301,6 +1318,10 @@ fn EPoll(comptime WSH: type) type {
                 .events = linux.EPOLL.IN | linux.EPOLL.RDHUP,
             };
             return posix.epoll_ctl(self.fd, linux.EPOLL.CTL_ADD, conn.getSocket(), &event);
+        }
+
+        fn remove(self: *Self, conn: *Conn(WSH)) void {
+            posix.epoll_ctl(self.fd, linux.EPOLL.CTL_DEL, conn.getSocket(), null) catch {};
         }
 
         fn rearmRead(self: *Self, conn: *Conn(WSH)) !void {


### PR DESCRIPTION
## Problem

In non-blocking mode, an HTTP connection's fd is armed level-triggered (`monitorRead`: `EPOLL.IN | RDHUP`, no ONESHOT) with the raw `Conn` pointer as epoll userdata. When a request finishes with `.close`/`.unknown`, `processHTTPData` closes the socket **on a worker thread** to (implicitly) drop it from epoll, then signals the loop; `processSignal` later recycles the `Conn` via the `MemoryPool` (`disown`), with no explicit `EPOLL_CTL_DEL`.

Closing the fd on the worker thread races `epoll_wait` on the loop thread. Under connection churn the fd can remain armed past the point where `disown` returns the `Conn` to the pool, so a later batch delivers a `.recv` carrying a pointer to freed memory. `protocol` is the first field of `Conn` and the `MemoryPool` free-list clobbers it, so the recycled node reads as `{ .http = null }` and `http_conn.getState()` dereferences null. We hit this in production as a recurring SIGSEGV in `getState` (`@atomicLoad(&self._state)`) at the `_state` offset, during normal operation, every few hours.

The deferred-signal change only orders signal-vs-recv within a single batch; it does not cover a `.recv` delivered in a later batch for an already-recycled `Conn`. `HTTPConn.disown` already does a synchronous `EPOLL_CTL_DEL` for the `res.disown()` path, for the same reason; the `.close`/`.unknown` path just relied on the worker-thread `close()` instead.

## Fix

Move teardown of `.close`/`.unknown` connections onto the loop thread: drop the worker-thread `posix.close`, and in `processSignal` remove the fd from the event loop (`EPOLL_CTL_DEL` / `EV.DELETE`) and close it **before** `disown` recycles the `Conn`. Since the fd is still open at that point, the DEL is valid, and no later batch can reference the freed `Conn`. A `remove` helper is added to both the epoll and kqueue loops, mirroring `HTTPConn.disown`.

The signal-vs-recv-in-one-batch case the worker-thread close used to guard is already handled by deferring signal processing to the end of the batch plus the `getState()` `.handover` check in the recv path.

Builds clean on 0.16; full test suite (125 tests) passes.