### PR TITLE
worker: join thread pool before websocket.deinit frees connection buffers

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -501,14 +501,18 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
         pub fn deinit(self: *Self) void {
             const allocator = self.allocator;
 
+            // Join in-flight handlers before freeing ANY connection state they
+            // may still be reading. run() only stops the event loop, so a handler
+            // can still be mid-callback here. This must come before
+            // websocket.deinit(), which frees the per-connection read buffers via
+            // buffer_provider.deinit(): a handler still in dataAvailable() can be
+            // reading a parsed message that holds zero-copy slices into those
+            // buffers, so joining afterward would be too late -> use-after-free.
+            self.thread_pool.stop();
+
             self.websocket.deinit();
             allocator.destroy(self.websocket);
 
-            // Join in-flight handlers before freeing the pool. run() only stops
-            // the event loop, so a handler can still be mid-callback here; without
-            // this, deinit frees its stack/buffer (and the caller proceeds to tear
-            // down resources the handler is still using) -> use-after-free.
-            self.thread_pool.stop();
             self.thread_pool.deinit();
 
             self.shutdownList(&self.request_list);


### PR DESCRIPTION
Follow-up to #215. That PR added `thread_pool.stop()` to the non-blocking `Worker.deinit`, but placed it *after* `self.websocket.deinit()`:

```zig
self.websocket.deinit();      // frees per-connection read buffers (buffer_provider.deinit)
allocator.destroy(self.websocket);
self.thread_pool.stop();      // joins in-flight handlers - too late
self.thread_pool.deinit();
```

`websocket.deinit()` -> `WorkerState.deinit()` -> `buffer_provider.deinit()` frees the per-connection read buffers. A worker-pool thread can still be inside `dataAvailable()` processing a message whose parsed view holds zero-copy slices into one of those buffers, so freeing them before the join is a use-after-free. We hit this on shutdown as a SIGSEGV in the message handler (a WebSocket request whose parsed fields point into the freed read buffer).

Fix: hoist `thread_pool.stop()` to the top of `deinit`, before any connection state it may still be reading is freed. By `deinit` the event loop is already stopped (`loop.stop()` via `server.stop()`), so no new work is dispatched; the running handler completes against still-valid buffers, then teardown proceeds. `stop()` remains idempotent.

Builds clean on 0.16; full test suite passes.