### PR TITLE
Bump websocket.zig dependency to latest master (7afc284)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "metrics-0.0.0-W7G4eIegAQD4XxA9Co7Atbw59u_2zvxYf406AZuoAHPM",
         },
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/99df0d3533a41cbcd5ff59b9af68bbfe6169cc62.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdangBAAgWPap_MVU6Nk4rj3GT3xuJuF0IIv8HN6G",
+            .url = "https://github.com/karlseguin/websocket.zig/archive/7afc284bd81a637d240f1cefba05677057f4d052.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdTPpBADCh019Gx0NnBhOAuHDulyjcquKIkz2Yu-_",
         },
         // .websocket = .{ .path = "../websocket.zig" },
     },


### PR DESCRIPTION
Bumps the pinned `websocket.zig` dependency from `99df0d3` to current master `7afc284`, picking up the Windows AFD fixes (https://github.com/karlseguin/websocket.zig/pull/105) and the TLS client read improvement.

Downstream projects that depend on both http.zig and websocket.zig directly need the two websocket pins to resolve to one package; keeping http.zig's pin current avoids a version conflict.

`zig build` and `zig build test` pass on 0.16.