### PR TITLE
Bump websocket.zig dependency to latest master (b70e733)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "metrics-0.0.0-W7G4eIegAQD4XxA9Co7Atbw59u_2zvxYf406AZuoAHPM",
         },
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/8df1a3394650d94272fe3643de33dba0a0c88c4f.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdX3sBABVt-aHuCBmwv_sCDwAoc9jO4AuqlFxqn6z",
+            .url = "https://github.com/karlseguin/websocket.zig/archive/b70e733bc0d0ba0a98ff5fe5ef64d3017c85f369.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdUoQBQC7zw1uSwbOEYdxZiTxNN4nf9RlWBsN0_Nd",
         },
         // .websocket = .{ .path = "../websocket.zig" },
     },


### PR DESCRIPTION
Bumps the pinned `websocket.zig` dependency from `8df1a33` to current master `b70e733`, picking up the client connect/handshake timeout (#108) and the read-timeout INT_MAX clamp (#110).

Keeps http.zig's websocket pin current so downstream projects that depend on both http.zig and websocket.zig directly resolve the two websocket pins to a single package.

`zig build` passes on 0.16.