### PR TITLE
fix: close listener on startup errors

### DIFF
--- a/src/httpz.zig
+++ b/src/httpz.zig
@@ -364,6 +364,11 @@ pub fn Server(comptime H: type) type {
                 break :blk try posix.socket(address.any.family, sock_flags, proto);
             };
 
+            errdefer {
+                posix.close(listener);
+                self._listener = null;
+            }
+
             if (is_unix_socket) {
                 // TODO: Broken on darwin:
                 // https://github.com/ziglang/zig/issues/17260


### PR DESCRIPTION
## What

Close the listener descriptor when `Server.listen` fails after socket creation and clear `_listener` if ownership had already been recorded.

## Why

Bind, listen, socket-option, or worker-startup errors currently return without closing the descriptor. The cleanup is scoped with `errdefer`, so successful server lifecycles are unchanged.

## Verification

- `zig build test` (125/125 tests passed)