### PR TITLE
Fix timeout sweep dropping surviving connections from the list

### DIFF
--- a/src/worker.zig
+++ b/src/worker.zig
@@ -970,6 +970,10 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             while (conn) |c| {
                 const timeout = c.protocol.http.timeout;
                 if (timeout > now) {
+                    // The expired connections ahead of this one were moved into
+                    // `timed_out` and are about to be destroyed, so this node
+                    // must not keep pointing back into them.
+                    c.prev = null;
                     list.head = c;
                     return .{ timed_out, count, timeout };
                 }
@@ -982,12 +986,18 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             return .{ timed_out, count, null };
         }
 
+        // `list` holds connections that collectTimedOut already detached from
+        // request_list/keepalive_list, so they must not be removed from those
+        // again. disown() would do exactly that, and List.remove rewrites head
+        // and tail from a node that is no longer a member.
         fn closeList(self: *Self, list: List(Conn(WSH))) void {
             var conn = list.head;
             while (conn) |c| {
                 conn = c.next;
                 c.close();
-                self.disown(c);
+                self.len -= 1;
+                self.http_conn_pool.release(c.protocol.http);
+                self.conn_mem_pool.destroy(c);
             }
         }
 


### PR DESCRIPTION
`collectTimedOut` splices the expired prefix of `request_list` / `keepalive_list` into a separate list and makes the first surviving connection the new head, but leaves that survivor's `prev` pointing at the last expired node. `closeList` then calls `disown` on each expired connection, which removes it from the original list a *second* time. `List.remove` rewrites `head`/`tail` from `node.prev`/`node.next`, so removing a node that is no longer a member walks those pointers through the detached chain.

With a mix of expired and surviving connections, the survivors are silently dropped from the list.

### Trace

`request_list` is `A -> B -> C`, `timeout.request = 10`, A and B expired, C not.

1. `collectTimedOut` moves A and B into `timed_out`. `insert` rewrites their `prev`/`next`, so `A.prev = null` and `B.next = null`.
2. It stops at C: `list.head = C`, but `C.prev` is still `B`, and `list.tail` is still `C`.
3. `closeList` → `disown(A)` → `request_list.remove(A)`. `A.prev == null`, so `head = A.next`, which is `B` — a connection about to be destroyed.
4. `disown(B)` → `remove(B)`. `B.prev == null` so `head = B.next = null`; `B.next == null` so `tail = B.prev = null`.

`request_list` is now `{head: null, tail: null}` while C is still open, still in the event loop, and still counted in `self.len`. C can never be reaped, so it holds a worker slot for the lifetime of the process, and `C.prev` points at a `Conn` already returned to `conn_mem_pool` — a later `swapList`/`disown` on C writes through it.

A flood that expires all at once is unaffected: the loop drains the whole list and takes the clean `head = null; tail = null` reset at the end. It needs a staggered mix, which ordinary traffic produces.

### Reproduction

Against an otherwise idle server with `timeout.request = 10`, open three connections three seconds apart and send nothing on any of them:

```sh
for d in 0 3 6; do
  ( sleep $d; exec 3<>/dev/tcp/127.0.0.1/PORT; sleep 60 ) &
done
ss -tn "sport = :PORT"
```

Before: the first connection is closed at its 10s deadline, the other two stay `ESTAB` indefinitely.
After: they are closed at 10s, 13s and 16s.

### Fix

Clear the survivor's `prev` when it becomes the head, and release the already-detached connections directly instead of routing them back through `disown`, which would remove them from a list they are no longer in.

`zig build test` passes (125/125).

I did not add a regression test: `collectTimedOut` is a private function over `Conn(WSH)`, so covering it needs either real `Conn`/`HTTPConn` instances or extracting the prefix-split into a `List` method. Happy to do either if you have a preference.
